### PR TITLE
Add external question deck

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -1,0 +1,3 @@
+# Improvements Log
+- Added external questions.json and asynchronous loader for dynamic trivia.
+- Hooked state and UI to pull random questions and process answers.

--- a/questions/questions.json
+++ b/questions/questions.json
@@ -1,0 +1,130 @@
+[
+  {
+    "questionId": 1,
+    "category": "Mind",
+    "title": "The Shape of Things",
+    "text": "Which of these has 3 sides?",
+    "answers": [
+      {
+        "text": "Triangle",
+        "answerClass": "Typical",
+        "explanation": "Correct. A triangle has 3 sides. Classic geometry.",
+        "changePoint": 2,
+        "changeThread": 0,
+        "traitChanges": { "X": 1, "Y": 0, "Z": -1 }
+      },
+      {
+        "text": "Square",
+        "answerClass": "Revelatory",
+        "explanation": "Correct. A square has 3 sides… and one more.",
+        "changePoint": 1,
+        "changeThread": 1,
+        "traitChanges": { "X": -1, "Y": 2, "Z": 0 }
+      },
+      {
+        "text": "Circle",
+        "answerClass": "Wrong",
+        "explanation": "Incorrect. A circle is a curve with no sides.",
+        "changePoint": 0,
+        "changeThread": -1,
+        "traitChanges": { "X": 0, "Y": -1, "Z": -1 }
+      }
+    ]
+  },
+  {
+    "questionId": 2,
+    "category": "Mind",
+    "title": "Capital Offense",
+    "text": "What is the capital of France?",
+    "answers": [
+      {
+        "text": "Paris",
+        "answerClass": "Typical",
+        "explanation": "Correct. Paris is the capital of France.",
+        "changePoint": 2,
+        "changeThread": 0,
+        "traitChanges": { "X": 1, "Y": 0, "Z": 0 }
+      },
+      {
+        "text": "The letter F",
+        "answerClass": "Revelatory",
+        "explanation": "Correct! 'F' is the capital letter in 'France.' Clever.",
+        "changePoint": 1,
+        "changeThread": 1,
+        "traitChanges": { "X": 0, "Y": 2, "Z": 1 }
+      },
+      {
+        "text": "Versailles",
+        "answerClass": "Wrong",
+        "explanation": "Incorrect.Versailles was once the capital of France, specifically from 1682 to 1789 .",
+        "changePoint": 0,
+        "changeThread": -1,
+        "traitChanges": { "X": -1, "Y": -1, "Z": 0 }
+      }
+    ]
+  },
+  {
+    "questionId": 3,
+    "category": "Mind",
+    "title": "No it isn’t",
+    "text": "What is between 1 and 3?",
+    "answers": [
+      {
+        "text": "2",
+        "answerClass": "Typical",
+        "explanation": "Correct. Numerically, 2 is between 1 and 3.",
+        "changePoint": 2,
+        "changeThread": 0,
+        "traitChanges": { "X": 1, "Y": 0, "Z": 0 }
+      },
+      {
+        "text": "and",
+        "answerClass": "Revelatory",
+        "explanation": "Correct! In the text, the word 'and' is between 1 and 3.",
+        "changePoint": 1,
+        "changeThread": 1,
+        "traitChanges": { "X": 0, "Y": 2, "Z": 1 }
+      },
+      {
+        "text": "what",
+        "answerClass": "Wrong",
+        "explanation": "Incorrect. 'what' is a part of the question, not a value between.",
+        "changePoint": 0,
+        "changeThread": -1,
+        "traitChanges": { "X": -1, "Y": -1, "Z": 0 }
+      }
+    ]
+  },
+  {
+    "questionId": 4,
+    "category": "Body",
+    "title": "An Eye Witness",
+    "text": "What can’t you do if your eyes are closed?",
+    "answers": [
+      {
+        "text": "See",
+        "answerClass": "Typical",
+        "explanation": "Correct. You can’t see with your eyes closed.",
+        "changePoint": 2,
+        "changeThread": 0,
+        "traitChanges": { "X": 1, "Y": 0, "Z": 0 }
+      },
+      {
+        "text": "Close them",
+        "answerClass": "Revelatory",
+        "explanation": "Correct! If they’re already closed, you can’t close them again.",
+        "changePoint": 1,
+        "changeThread": 1,
+        "traitChanges": { "X": 0, "Y": 2, "Z": 1 }
+      },
+      {
+        "text": "Read",
+        "answerClass": "Wrong",
+        "explanation": "Incorrect. you don’t need to see in order to read braille, eyes closed or open, you can still read.",
+        "changePoint": 0,
+        "changeThread": -1,
+        "traitChanges": { "X": -1, "Y": -1, "Z": 0 }
+      }
+    ]
+  }
+]

--- a/script.js
+++ b/script.js
@@ -8,7 +8,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const controller = document.getElementById('controller');
 
   // --- Game Initialization ---
-  function init() {
+  async function init() {
+    await State.loadQuestions();
     UI.updateScreen('welcome');
     console.log('[INIT]: Nous initialized. Welcome.');
   }
@@ -29,11 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
     switch (action) {
       // --- Navigation ---
       case 'start-game':
-case 'start-game':
-  UI.showParticipantEntry(); // prompt input
-  break;
-        UI.updateScreen('game-lobby');
-        UI.updateDisplayValues(currentState);
+        UI.showParticipantEntry(); // prompt input
         break;
       case 'go-rules':
         UI.updateScreen('rules');
@@ -78,23 +75,27 @@ case 'start-game':
         console.log('[ACTION]: Using 1 Thread to double next points (placeholder).');
         break;
       case 'start-question':
-        UI.showQuestion({
-          title: 'Mind, Past',
-          text: 'Which philosopher wrote "Critique of Pure Reason"?',
-          choices: {
-            A: 'Nietzsche',
-            B: 'Kant',
-            C: 'Socrates'
-          }
-        });
-        UI.updateScreen('question');
+        const q = State.getNextQuestion();
+        if (q) {
+          UI.showQuestion({
+            title: q.title,
+            text: q.text,
+            choices: {
+              A: q.answers[0].text,
+              B: q.answers[1].text,
+              C: q.answers[2].text
+            }
+          });
+          UI.updateScreen('question');
+        }
         break;
 
       // --- Answer Selection ---
       case 'answer-a':
       case 'answer-b':
       case 'answer-c':
-        evaluateAnswer(action);
+        const letter = action.split('-')[1].toUpperCase();
+        evaluateAnswer(letter);
         break;
 
       // --- Post Result Actions ---
@@ -108,17 +109,13 @@ case 'start-game':
     }
   }
 
-  // --- Sample Answer Evaluation ---
-  function evaluateAnswer(action) {
-    const isCorrect = action === 'answer-b'; // Kant
-    UI.showResult({
-      correct: isCorrect,
-      question: 'Which philosopher wrote "Critique of Pure Reason"?',
-      answer: isCorrect ? 'Immanuel Kant' : 'Incorrect choice',
-      explanation: 'Kant\'s work is a cornerstone of modern philosophy.',
-      outcomeText: isCorrect ? 'The thread holds.' : 'A strand slips through your fingers...'
-    });
-    UI.updateScreen('result');
+  // --- Answer Evaluation ---
+  function evaluateAnswer(letter) {
+    const result = State.evaluateAnswer(letter);
+    if (result) {
+      UI.showResult(result);
+      UI.updateScreen('result');
+    }
   }
 
   // --- Start the Game ---


### PR DESCRIPTION
## Summary
- load questions from `questions/questions.json`
- adjust `state.js` for dynamic question deck and evaluation
- adapt `script.js` to use dynamic questions
- record improvements

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6877f6e83a0483328db228bb179151b5