### PR TITLE
Fix lobby init with participant count

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -1,3 +1,4 @@
 # Improvements Log
 - Added external questions.json and asynchronous loader for dynamic trivia.
 - Hooked state and UI to pull random questions and process answers.
+- Added setParticipants export and initialization on confirm to prevent lobby errors when starting a game.

--- a/state.js
+++ b/state.js
@@ -169,6 +169,7 @@ const setParticipants = (count) => {
     loadQuestions,
     getState,
     setState,
+    setParticipants,
     resetGame,
     drawDivination,
     startNewRound,

--- a/ui.js
+++ b/ui.js
@@ -139,6 +139,7 @@ confirmBtn.addEventListener('click', () => {
   const count = parseInt(participantInput.value);
   if (count >= 1 && count <= 20) {
     State.setParticipants(count);
+    State.initializeGame(count);
     flavorLine.textContent = `Strange... it looks like there are ${count + 1} of you here. Ah well.`;
     flavorLine.hidden = false;
     setTimeout(() => {


### PR DESCRIPTION
## Summary
- export `setParticipants` from `state.js`
- reset game state when confirming participants
- note improvement in the log

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68780f710e3c8332b7f327e794eb5357