### PR TITLE
Update UI display for rounds and category

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -2,3 +2,4 @@
 - Added external questions.json and asynchronous loader for dynamic trivia.
 - Hooked state and UI to pull random questions and process answers.
 - Added setParticipants export and initialization on confirm to prevent lobby errors when starting a game.
+- Updated UI display to use roundsToWin and currentCategory, removed unused rounds state.

--- a/state.js
+++ b/state.js
@@ -29,7 +29,6 @@ const State = (() => {
 const setParticipants = (count) => {
   gameState.participants = count;
   gameState.lives = count + 1;
-  gameState.rounds = 3; // wins required to finish
 };
 
   // --- Stubs for Game Data ---
@@ -86,7 +85,8 @@ const setParticipants = (count) => {
   const startNewRound = () => {
     gameState.roundNumber++;
     gameState.roundScore = 0;
-    gameState.thread = gameState.rounds + 1; // thread = remaining round wins + 1
+    const remainingWins = gameState.roundsToWin - gameState.roundsWon;
+    gameState.thread = remainingWins + 1; // thread = remaining round wins + 1
   };
 
   const endRound = (won = false) => {

--- a/ui.js
+++ b/ui.js
@@ -150,14 +150,31 @@ confirmBtn.addEventListener('click', () => {
 });
 
   const updateDisplayValues = (data) => {
-    if ('lives' in data) document.getElementById('lives-display').textContent = data.lives;
-    if ('rounds' in data) document.getElementById('rounds-display').textContent = data.rounds;
-    if ('score' in data) document.getElementById('score-display').textContent = data.score;
-    if ('thread' in data) document.getElementById('thread-display').textContent = data.thread;
-    if ('roundScore' in data) document.getElementById('round-score').textContent = data.roundScore;
-    if ('roundNumber' in data) document.getElementById('round-number-display').textContent = data.roundNumber;
-    if ('category' in data) document.getElementById('category-hint').textContent = data.category;
-    if ('divinations' in data) document.getElementById('active-divinations').textContent = data.divinations.join(', ');
+    if ('lives' in data) {
+      document.getElementById('lives-display').textContent = data.lives;
+    }
+    if ('roundsToWin' in data && 'roundsWon' in data) {
+      const remaining = data.roundsToWin - data.roundsWon;
+      document.getElementById('rounds-display').textContent = remaining;
+    }
+    if ('score' in data) {
+      document.getElementById('score-display').textContent = data.score;
+    }
+    if ('thread' in data) {
+      document.getElementById('thread-display').textContent = data.thread;
+    }
+    if ('roundScore' in data) {
+      document.getElementById('round-score').textContent = data.roundScore;
+    }
+    if ('roundNumber' in data) {
+      document.getElementById('round-number-display').textContent = data.roundNumber;
+    }
+    if ('currentCategory' in data) {
+      document.getElementById('category-hint').textContent = data.currentCategory;
+    }
+    if ('divinations' in data) {
+      document.getElementById('active-divinations').textContent = data.divinations.join(', ');
+    }
   };
 
   const showQuestion = (q) => {


### PR DESCRIPTION
## Summary
- remove unused `rounds` state and compute thread using `roundsToWin`
- reflect new state fields in `UI.updateDisplayValues`
- log update in improvements log

## Testing
- `node --check state.js && node --check ui.js`


------
https://chatgpt.com/codex/tasks/task_e_6878104c0dc48332a932cf76287d8ae6