### PR TITLE
Initialize game on start and confirm

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -3,3 +3,4 @@
 - Hooked state and UI to pull random questions and process answers.
 - Added setParticipants export and initialization on confirm to prevent lobby errors when starting a game.
 - Updated UI display to use roundsToWin and currentCategory, removed unused rounds state.
+- Triggered game initialization on start-game and participant confirmation so UI resets cleanly.

--- a/script.js
+++ b/script.js
@@ -30,6 +30,8 @@ document.addEventListener('DOMContentLoaded', () => {
     switch (action) {
       // --- Navigation ---
       case 'start-game':
+        State.initializeGame(State.getState().participants || 1);
+        UI.updateDisplayValues(State.getState());
         UI.showParticipantEntry(); // prompt input
         break;
       case 'go-rules':

--- a/ui.js
+++ b/ui.js
@@ -140,6 +140,7 @@ confirmBtn.addEventListener('click', () => {
   if (count >= 1 && count <= 20) {
     State.setParticipants(count);
     State.initializeGame(count);
+    UI.updateDisplayValues(State.getState());
     flavorLine.textContent = `Strange... it looks like there are ${count + 1} of you here. Ah well.`;
     flavorLine.hidden = false;
     setTimeout(() => {


### PR DESCRIPTION
## Summary
- initialize the game state as soon as the **start-game** action is triggered
- update UI values when participants confirm
- log the change

## Testing
- `node -c state.js`
- `node -c ui.js`
- `node -c script.js` *(fails: Unexpected token '*')*

------
https://chatgpt.com/codex/tasks/task_e_687811cfdf3083328623fd6f99b42776