### PR TITLE
Fix thread calculation

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -4,3 +4,4 @@
 - Added setParticipants export and initialization on confirm to prevent lobby errors when starting a game.
 - Updated UI display to use roundsToWin and currentCategory, removed unused rounds state.
 - Triggered game initialization on start-game and participant confirmation so UI resets cleanly.
+- Calculated thread length from roundsToWin and roundsWon for consistent gameplay.

--- a/state.js
+++ b/state.js
@@ -59,7 +59,8 @@ const setParticipants = (count) => {
     gameState.roundNumber = 1;
     gameState.score = 0;
     gameState.roundScore = 0;
-    gameState.thread = 4; // Can be scaled to round or difficulty later
+    const remainingWins = gameState.roundsToWin - gameState.roundsWon;
+    gameState.thread = remainingWins + 1; // thread = remaining round wins + 1
     gameState.divinations = [];
     gameState.audacity = 0;
     gameState.currentCategory = 'Mind, Past';


### PR DESCRIPTION
## Summary
- compute starting thread from remaining rounds
- log change

## Testing
- `node -e "require('./state.js'); console.log('load ok');"`
- `node -e "require('./script.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6878133c98b08332a092aeb5d5387706