### PR TITLE
Implement menu navigation on welcome screen

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -7,3 +7,4 @@
 - Added defer attributes to script tags so buttons initialize correctly.
 - Calculated thread length from roundsToWin and roundsWon for consistent gameplay.
 - Configured package.json for Jest with jsdom environment to enable testing of browser scripts.
+- Implemented button-controlled menu navigation on the welcome screen so Up/Select/Down cycle choices and selecting Play prompts participant entry.

--- a/script.js
+++ b/script.js
@@ -28,6 +28,23 @@ document.addEventListener('DOMContentLoaded', () => {
 
     switch (action) {
       // --- Navigation ---
+      case 'welcome-up':
+        UI.moveWelcomeSelection('up');
+        break;
+      case 'welcome-down':
+        UI.moveWelcomeSelection('down');
+        break;
+      case 'welcome-select': {
+        const choice = UI.getWelcomeSelection();
+        if (choice === 'Play') {
+          handleAction('start-game');
+        } else if (choice === 'Rules') {
+          handleAction('go-rules');
+        } else if (choice === 'Options') {
+          handleAction('go-options');
+        }
+        break;
+      }
       case 'start-game':
         State.initializeGame(State.getState().participants || 1);
         UI.updateDisplayValues(State.getState());

--- a/style.css
+++ b/style.css
@@ -1,0 +1,4 @@
+.selected {
+  background: #444;
+  color: #fff;
+}

--- a/ui.js
+++ b/ui.js
@@ -5,15 +5,16 @@ const validActions = new Set([
   'end-round', 'double-points', 'start-question',
   'answer-a', 'answer-b', 'answer-c',
   'challenge-result', 'accept-result', 'return-to-lobby',
-  'restart-game', 'save-reading', 'quit-game'
+  'restart-game', 'save-reading', 'quit-game',
+  'welcome-up', 'welcome-down', 'welcome-select'
 ]);
 
 // === Button Configurations by Screen === //
 const buttonConfigs = {
   welcome: [
-    { label: "Select", action: "start-game" },
-    { label: "Rules", action: "go-rules" },
-    { label: "Options", action: "go-options" }
+    { label: "Up", action: "welcome-up" },
+    { label: "Select", action: "welcome-select" },
+    { label: "Down", action: "welcome-down" }
   ],
   rules: [
     { label: "Back", action: "back-to-welcome" },
@@ -83,6 +84,27 @@ const UI = (() => {
 
   const screens = document.querySelectorAll('.game-screen');
 
+  // --- Welcome Screen Option Navigation ---
+  const welcomeOptions = Array.from(document.querySelectorAll('#welcome-options li'));
+  let welcomeIndex = 0;
+
+  const updateWelcomeHighlight = () => {
+    welcomeOptions.forEach((li, idx) => {
+      li.classList.toggle('selected', idx === welcomeIndex);
+    });
+  };
+
+  const moveWelcomeSelection = (dir) => {
+    if (dir === 'up') {
+      welcomeIndex = (welcomeIndex - 1 + welcomeOptions.length) % welcomeOptions.length;
+    } else if (dir === 'down') {
+      welcomeIndex = (welcomeIndex + 1) % welcomeOptions.length;
+    }
+    updateWelcomeHighlight();
+  };
+
+  const getWelcomeSelection = () => welcomeOptions[welcomeIndex]?.textContent.trim();
+
   const updateScreen = (screenName) => {
     screens.forEach(screen => {
       screen.hidden = true;
@@ -100,6 +122,10 @@ const UI = (() => {
     if (agentLog) agentLog.textContent = `Last state: ${screenName}`;
 
     configureButtons(screenName);
+
+    if (screenName === 'welcome') {
+      updateWelcomeHighlight();
+    }
   };
 
   const configureButtons = (screenName) => {
@@ -204,6 +230,10 @@ confirmBtn.addEventListener('click', () => {
     updateDisplayValues,
     showQuestion,
     showResult,
-    showFailure
+    showFailure,
+    showParticipantEntry,
+    hideParticipantEntry,
+    moveWelcomeSelection,
+    getWelcomeSelection
   };
 })();


### PR DESCRIPTION
## Summary
- hook up Up/Select/Down navigation for the welcome menu
- expose participant entry helpers and new navigation utilities in UI module
- wire new actions into script engine
- add simple style for selected menu item
- log improvement

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687817f9a8c4833288bf9ae1d5e0ef4d