### PR TITLE
Fix thread scoring and UI updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
             <h2>Round <span id="round-number-display">[#]</span></h2>
             <div class="round-display">
                 <p>Active Divinations: <span id="active-divinations">[None]</span></p>
-                <p>Current Round Score: <span id="round-score">[#]</span></p>
+                <p>Points Earned this Round: <span id="round-score">[#]</span></p>
                 <p>Thread Length Remaining: <span id="thread-display">[#]</span></p>
                 <p>Next Category: <span id="category-hint">[Faded Ink]</span></p>
             </div>

--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -9,3 +9,6 @@
 - Configured package.json for Jest with jsdom environment to enable testing of browser scripts.
 - Implemented button-controlled menu navigation on the welcome screen so Up/Select/Down cycle choices and selecting Play prompts participant entry.
 - Implemented thread and scoring logic for pull/cut actions to track round progress.
+- Fixed round scoring and thread updates to reflect correct answers and round completion.
+- Starting new rounds now resets thread and displays updated scores.
+- Weave action consumes thread and randomizes the upcoming category.

--- a/script.js
+++ b/script.js
@@ -81,6 +81,8 @@ document.addEventListener('DOMContentLoaded', () => {
         console.log('[ACTION]: Pulling divination (placeholder).');
         break;
       case 'next-round':
+        State.startNewRound();
+        UI.updateDisplayValues(State.getState());
         UI.updateScreen('round-lobby');
         break;
 
@@ -96,7 +98,12 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         break;
       case 'double-points':
-        console.log('[ACTION]: Using 1 Thread to double next points (placeholder).');
+        if (State.spendThreadToWeave()) {
+          State.shuffleNextCategory();
+          UI.updateDisplayValues(State.getState());
+        } else {
+          console.log('[ACTION]: Not enough Thread to weave.');
+        }
         break;
       case 'start-question':
         State.pullThread();

--- a/state.js
+++ b/state.js
@@ -94,6 +94,7 @@ const setParticipants = (count) => {
     gameState.thread = remainingWins + 1; // thread = remaining round wins + 1
     gameState.notWrongCount = 0;
     gameState.roundPassed = false;
+    gameState.currentCategory = 'Mind, Past';
   };
 
   const endRound = (won = false) => {
@@ -121,7 +122,7 @@ const setParticipants = (count) => {
   };
 
   const cutThread = () => {
-    const success = gameState.thread > 0;
+    const success = gameState.notWrongCount >= 3 && gameState.thread > 0;
     endRound(success);
     if (!success) {
       loseRoundPoints();


### PR DESCRIPTION
## Summary
- display `Points Earned this Round` in round lobby
- reset thread and category when starting a new round
- require three correct answers to cut the thread successfully
- allow weaving the next category at the cost of one thread
- refresh lobby info when moving to the next round
- log improvement entries

## Testing
- `npm install`
- `npx jest --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_687821187ae88332a816812ff302289c