### PR TITLE
Fix round completion logic

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -13,3 +13,4 @@
 - Starting new rounds now resets thread and displays updated scores.
 - Weave action consumes thread and randomizes the upcoming category.
 - Enhanced UI with mystical styling and button labels to deepen atmospheric immersion.
+- Fixed round threshold logic so lobby updates only after cutting, enabling proper scoring and life tracking.

--- a/script.js
+++ b/script.js
@@ -135,9 +135,7 @@ document.addEventListener('DOMContentLoaded', () => {
       // --- Post Result Actions ---
       case 'accept-result':
         UI.updateDisplayValues(State.getState());
-        if (State.getState().roundPassed) {
-          UI.updateScreen('game-lobby');
-        } else if (State.getState().thread <= 0) {
+        if (State.getState().thread <= 0) {
           UI.showFailure(State.getState().roundScore);
           State.endRound(false);
           UI.updateScreen('failure');

--- a/state.js
+++ b/state.js
@@ -173,6 +173,9 @@ const setParticipants = (count) => {
 
     if (gameState.notWrongCount >= 3) {
       gameState.roundPassed = true;
+      if (gameState.difficulty === 'standard') {
+        gameState.difficulty = 'advanced';
+      }
     }
 
     return {


### PR DESCRIPTION
## Summary
- keep players in the round after three correct answers
- escalate difficulty once the threshold is hit
- ensure lobby scores update only when cutting the thread

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687824e157bc8332b6ad7ba6b0016b39