### PR TITLE
Add menu highlight and transition effect

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -16,3 +16,4 @@
 - Fixed round threshold logic so lobby updates only after cutting, enabling proper scoring and life tracking.
 - Added waiting room screen with button-based participant selection to streamline game start.
 - Centered main screen with updated flex layout so buttons sit neatly below for better focus.
+- Added menu highlight and transition overlay to clarify selections.

--- a/style.css
+++ b/style.css
@@ -136,3 +136,71 @@ body::after {
   width: 100%;
   z-index: 1;
 }
+
+/* === Text Styling === */
+.game-screen {
+  font-size: 1.5rem;
+  line-height: 1.6;
+}
+
+.game-screen p,
+.game-screen li {
+  text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.4);
+}
+
+.game-screen h1,
+.game-screen h2,
+.game-screen h3,
+.game-screen .highlight {
+  background: linear-gradient(to top, var(--gold-foil-dark), var(--gold-foil-light));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+}
+
+/* === Welcome Option Highlight === */
+#welcome-options {
+  list-style: none;
+  margin-top: 1rem;
+}
+
+#welcome-options li {
+  margin: 0.5rem 0;
+  position: relative;
+}
+
+#welcome-options li.selected {
+  color: var(--gold-foil-light);
+}
+
+#welcome-options li.selected::before {
+  content: '\25B6';
+  position: absolute;
+  left: -1.5rem;
+  color: var(--gold-foil-light);
+}
+
+/* === Screen Transition Effect === */
+#app-container {
+  position: relative;
+}
+
+#app-container::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #000;
+  z-index: 100;
+  clip-path: circle(0% at 50% 50%);
+  transition: clip-path 0.7s cubic-bezier(0.4, 0, 0.2, 1);
+  pointer-events: none;
+}
+
+#app-container.is-transitioning::before {
+  clip-path: circle(75% at 50% 50%);
+  pointer-events: auto;
+}

--- a/ui.js
+++ b/ui.js
@@ -118,26 +118,34 @@ const UI = (() => {
   const getWelcomeSelection = () => welcomeOptions[welcomeIndex]?.textContent.trim();
 
   const updateScreen = (screenName) => {
-    screens.forEach(screen => {
-      screen.hidden = true;
-      screen.setAttribute('aria-hidden', 'true');
-    });
+    // Trigger "inky black" transition
+    appContainer.classList.add('is-transitioning');
 
-    const newScreen = document.querySelector(`[data-screen="${screenName}"]`);
-    if (newScreen) {
-      newScreen.hidden = false;
-      newScreen.setAttribute('aria-hidden', 'false');
-    }
+    setTimeout(() => {
+      screens.forEach(screen => {
+        screen.hidden = true;
+        screen.setAttribute('aria-hidden', 'true');
+      });
 
-    appContainer.setAttribute('data-game-state', screenName);
-    controller.setAttribute('data-controller-state', screenName);
-    if (agentLog) agentLog.textContent = `Last state: ${screenName}`;
+      const newScreen = document.querySelector(`[data-screen="${screenName}"]`);
+      if (newScreen) {
+        newScreen.hidden = false;
+        newScreen.setAttribute('aria-hidden', 'false');
+      }
 
-    configureButtons(screenName);
+      appContainer.setAttribute('data-game-state', screenName);
+      controller.setAttribute('data-controller-state', screenName);
+      if (agentLog) agentLog.textContent = `Last state: ${screenName}`;
 
-    if (screenName === 'welcome') {
-      updateWelcomeHighlight();
-    }
+      configureButtons(screenName);
+
+      if (screenName === 'welcome') {
+        updateWelcomeHighlight();
+      }
+
+      // Remove transition class to fade back in
+      appContainer.classList.remove('is-transitioning');
+    }, 700);
   };
 
   const configureButtons = (screenName) => {


### PR DESCRIPTION
## Summary
- enhance text readability and highlight active welcome option
- add inky black screen transition and apply in ui.js
- log new improvement

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6878292b70748332909aa5bc6cfe35db