### PR TITLE
Add difficulty-based question progression

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -17,3 +17,4 @@
 - Added waiting room screen with button-based participant selection to streamline game start.
 - Centered main screen with updated flex layout so buttons sit neatly below for better focus.
 - Added menu highlight and transition overlay to clarify selections.
+- Implemented difficulty-based question selection with tracking of answered cards.


### PR DESCRIPTION
## Summary
- track difficulty levels and answered questions in game state
- advance difficulty when needed
- select questions based on current difficulty
- reset difficulty state on new games
- log the update in improvements log

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68782abc18d483329942bffb2cf12067