### PR TITLE
Fix participant init, load divinations

### DIFF
--- a/divinations/divinations.json
+++ b/divinations/divinations.json
@@ -1,0 +1,5 @@
+[
+  "A choice made in haste will ripple outwards.",
+  "Doubt is a shadow that you cast yourself.",
+  "The path of least resistance leads to the steepest fall."
+]

--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -19,3 +19,4 @@
 - Added menu highlight and transition overlay to clarify selections.
 - Reworked layout and welcome screen cursor to eliminate flicker and fix menu navigation.
 - Implemented difficulty-based question selection with tracking of answered cards.
+- Consolidated participant initialization and added external divination deck for smoother restarts.

--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // --- Game Initialization ---
   async function init() {
     await State.loadQuestions();
+    await State.loadDivinations();
     UI.updateScreen('welcome');
     console.log('[INIT]: Nous initialized. Welcome.');
   }
@@ -47,8 +48,6 @@ document.addEventListener('DOMContentLoaded', () => {
         break;
       }
       case 'start-game':
-        State.initializeGame(State.getState().participants || 1);
-        UI.updateDisplayValues(State.getState());
         UI.showParticipantEntry();
         break;
       case 'participants-up':
@@ -57,9 +56,16 @@ document.addEventListener('DOMContentLoaded', () => {
       case 'participants-down':
         UI.adjustParticipantCount(-1);
         break;
-      case 'participants-confirm':
-        UI.confirmParticipants();
+      case 'participants-confirm': {
+        const count = UI.confirmParticipants();
+        State.initializeGame(count);
+        UI.updateDisplayValues(State.getState());
+        setTimeout(() => {
+          UI.updateScreen('game-lobby');
+          UI.updateDisplayValues(State.getState());
+        }, 2000);
         break;
+      }
       case 'go-rules':
         UI.updateScreen('rules');
         break;

--- a/state.js
+++ b/state.js
@@ -32,19 +32,19 @@ const State = (() => {
     answeredQuestionIds: new Set()
   };
 
-const setParticipants = (count) => {
-  gameState.participants = count;
-  gameState.lives = count + 1;
-};
-
-  // --- Stubs for Game Data ---
-  const divinationDeck = [
-    "A choice made in haste will ripple outwards.",
-    "Doubt is a shadow that you cast yourself.",
-    "The path of least resistance leads to the steepest fall."
-  ];
-
+  // --- Game Data ---
+  let divinationDeck = [];
   let questionDeck = [];
+
+  const loadDivinations = async () => {
+    try {
+      const response = await fetch('divinations/divinations.json');
+      if (!response.ok) throw new Error('Failed to load divinations');
+      divinationDeck = await response.json();
+    } catch (err) {
+      console.error('[LOAD DIVINATIONS]', err);
+    }
+  };
 
   const loadQuestions = async () => {
     try {
@@ -59,6 +59,7 @@ const setParticipants = (count) => {
   // --- Public Methods ---
 
   const initializeGame = (participantCount = 1) => {
+    gameState.participants = participantCount;
     gameState.lives = participantCount + 1;
     gameState.roundsToWin = defaultSettings.roundsToWin;
     gameState.roundsWon = 0;
@@ -254,9 +255,9 @@ const setParticipants = (count) => {
   return {
     initializeGame,
     loadQuestions,
+    loadDivinations,
     getState,
     setState,
-    setParticipants,
     resetGame,
     drawDivination,
     startNewRound,

--- a/ui.js
+++ b/ui.js
@@ -192,15 +192,9 @@ const getParticipantCount = () => participantCount;
 
 const confirmParticipants = () => {
   const count = participantCount;
-  State.setParticipants(count);
-  State.initializeGame(count);
-  UI.updateDisplayValues(State.getState());
   flavorLine.textContent = `Strange... it looks like there are ${count + 1} of you here. Ah well.`;
   flavorLine.hidden = false;
-  setTimeout(() => {
-    UI.updateScreen('game-lobby');
-    UI.updateDisplayValues(State.getState());
-  }, 2000);
+  return count;
 };
 
   const updateDisplayValues = (data) => {


### PR DESCRIPTION
## Summary
- move divination deck to JSON and load at init
- consolidate participant initialization
- return participant count to controller
- log improvement

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68782e15ff9c8332876cde4147988b6f