### PR TITLE
Fix cut thread escape logic

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -25,3 +25,4 @@
 - Fixed Play button not advancing to participant entry by stripping arrow from welcome option text.
 - Introduced Fate Card system with new data file and state logic for immersive dynamics.
 - Restored thread and category functions so pull/cut/weave buttons operate again.
+- Adjusted cut thread to end a round without loss so players can escape safely.

--- a/state.js
+++ b/state.js
@@ -82,14 +82,20 @@ const State = (() => {
     gameState.currentCategory = 'Mind, Past';
   };
 
-  const endRound = (won = false) => {
+  const endRound = (outcome = 'lose') => {
     resolveRoundEffects(); // Resolve fate card effects first
 
-    if (won) {
+    switch (outcome) {
+      case 'win':
         gameState.roundsWon++;
         gameState.score += gameState.roundScore;
-    } else {
+        break;
+      case 'lose':
         gameState.lives--;
+        break;
+      case 'escape':
+        gameState.roundScore = 0;
+        break;
     }
     // ... rest of endRound logic
   };
@@ -107,12 +113,8 @@ const State = (() => {
   };
 
   const cutThread = () => {
-    const success = gameState.notWrongCount >= 3 && gameState.thread > 0;
-    endRound(success);
-    if (!success) {
-      loseRoundPoints();
-    }
-    return success;
+    endRound('escape');
+    return true;
   };
 
   const shuffleNextCategory = () => {


### PR DESCRIPTION
## Summary
- allow cut thread to end a round as an escape with no penalty
- log improvement

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6878523665a4833286706bfcf82ab5e2