### PR TITLE
Add fate card display and lobby updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,6 @@
               <p>How many will be participating in tonight’s experience?</p>
               <input type="number" id="participant-count" min="1" max="20" value="1" />
               <button id="confirm-participants">Confirm</button>
-              <p id="participant-flavor" class="flavor-text" hidden></p>
             </div>
         </section>
 
@@ -100,6 +99,17 @@
                 <p>A: <span id="answer-a">[Answer Option A]</span></p>
                 <p>B: <span id="answer-b">[Answer Option B]</span></p>
                 <p>C: <span id="answer-c">[Answer Option C]</span></p>
+            </div>
+        </section>
+
+        <!-- 6b. Fate Card Screen -->
+        <section id="screen-fate-card" class="game-screen" data-screen="fate-card">
+            <h2 id="fate-card-title">[Fate Title]</h2>
+            <p id="fate-card-text">[The whisper of destiny will appear here.]</p>
+            <div class="answer-options">
+                <p>A: <span id="fate-a-text">[Option A]</span></p>
+                <p>B: <span id="fate-b-text">[Option B]</span></p>
+                <p>C: <span id="fate-c-text">[Option C]</span></p>
             </div>
         </section>
 

--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -26,3 +26,4 @@
 - Introduced Fate Card system with new data file and state logic for immersive dynamics.
 - Restored thread and category functions so pull/cut/weave buttons operate again.
 - Adjusted cut thread to end a round without loss so players can escape safely.
+- Implemented fate card display and lobby updates for active effects.

--- a/script.js
+++ b/script.js
@@ -93,7 +93,14 @@ document.addEventListener('DOMContentLoaded', () => {
         console.log('[ACTION]: Save and quit (placeholder).');
         break;
       case 'pull-divination':
-        console.log('[ACTION]: Pulling divination (placeholder).');
+        const card = State.drawFateCard();
+        if (card) {
+          State.setCurrentFateCard(card);
+          UI.showFateCard(card);
+          UI.updateScreen('fate-card');
+        } else {
+          console.log('[ACTION]: No fate cards available');
+        }
         break;
       case 'next-round':
         State.startNewRound();
@@ -145,6 +152,17 @@ document.addEventListener('DOMContentLoaded', () => {
         const letter = action.split('-')[1].toUpperCase();
         evaluateAnswer(letter);
         break;
+
+      case 'fate-a':
+      case 'fate-b':
+      case 'fate-c': {
+        const idxMap = { 'fate-a': 0, 'fate-b': 1, 'fate-c': 2 };
+        const flavor = State.chooseFateOption(idxMap[action]);
+        UI.showFateResult(flavor);
+        UI.updateDisplayValues(State.getState());
+        UI.updateScreen('game-lobby');
+        break;
+      }
 
       // --- Post Result Actions ---
       case 'accept-result':

--- a/state.js
+++ b/state.js
@@ -25,6 +25,7 @@ const State = (() => {
     answeredQuestionIds: new Set(),
     completedFateCardIds: new Set(),
     activeRoundEffects: [],
+    currentFateCard: null,
     currentQuestion: null,
     notWrongCount: 0,
     currentCategory: 'Mind, Past',
@@ -66,6 +67,7 @@ const State = (() => {
         answeredQuestionIds: new Set(),
         completedFateCardIds: new Set(),
         activeRoundEffects: [],
+        currentFateCard: null,
         currentQuestion: null,
         notWrongCount: 0,
         currentCategory: 'Mind, Past',
@@ -79,6 +81,7 @@ const State = (() => {
     gameState.thread = gameState.roundsToWin - gameState.roundsWon + 1;
     gameState.notWrongCount = 0;
     gameState.activeRoundEffects = [];
+    gameState.currentFateCard = null;
     gameState.currentCategory = 'Mind, Past';
   };
 
@@ -144,14 +147,31 @@ const State = (() => {
     return availableCards[idx];
   };
 
-  const applyFateCardEffect = (effect) => {
+  const setCurrentFateCard = (card) => {
+    gameState.currentFateCard = card;
+  };
+
+  const getCurrentFateCard = () => gameState.currentFateCard;
+
+  const chooseFateOption = (index) => {
+    const card = gameState.currentFateCard;
+    if (!card) return null;
+    const choice = card.choices[index];
+    if (!choice) return null;
+    const flavor = applyFateCardEffect({ ...choice.effect }, card.title);
+    gameState.completedFateCardIds.add(card.id);
+    gameState.currentFateCard = null;
+    return flavor;
+  };
+
+  const applyFateCardEffect = (effect, title = '') => {
     if (!effect) return null;
 
     if (effect.type === 'IMMEDIATE_SCORE') {
         gameState.score += effect.value;
     } else {
         // Any other effect is considered a round-long effect
-        gameState.activeRoundEffects.push(effect);
+        gameState.activeRoundEffects.push({ ...effect, cardTitle: title });
     }
     return effect.flavorText || null;
   };
@@ -291,6 +311,9 @@ const State = (() => {
     getState: () => ({ ...gameState }),
     drawFateCard,
     applyFateCardEffect,
+    setCurrentFateCard,
+    getCurrentFateCard,
+    chooseFateOption,
     drawDivination,
     getNextQuestion,
     evaluateAnswer,

--- a/ui.js
+++ b/ui.js
@@ -7,7 +7,8 @@ const validActions = new Set([
   'challenge-result', 'accept-result', 'return-to-lobby',
   'restart-game', 'save-reading', 'quit-game',
   'welcome-up', 'welcome-down', 'welcome-select',
-  'participants-up', 'participants-confirm', 'participants-down'
+  'participants-up', 'participants-confirm', 'participants-down',
+  'fate-a', 'fate-b', 'fate-c'
 ]);
 
 // === Button Configurations by Screen === //
@@ -46,6 +47,11 @@ const buttonConfigs = {
     { label: "Choose A", action: "answer-a" },
     { label: "Choose B", action: "answer-b" },
     { label: "Choose C", action: "answer-c" }
+  ],
+  "fate-card": [
+    { label: "Choose A", action: "fate-a" },
+    { label: "Choose B", action: "fate-b" },
+    { label: "Choose C", action: "fate-c" }
   ],
   result: [
     { label: "Disagree", action: "challenge-result" },
@@ -230,6 +236,11 @@ const confirmParticipants = () => {
     if ('divinations' in data) {
       document.getElementById('active-divinations').textContent = data.divinations.join(', ');
     }
+    if ('activeRoundEffects' in data) {
+      const container = document.querySelector('#divinations-display p');
+      const titles = data.activeRoundEffects.map(e => e.cardTitle).filter(Boolean);
+      container.textContent = titles.length ? titles.join(', ') : '[None]';
+    }
   };
 
   const showQuestion = (q) => {
@@ -238,6 +249,17 @@ const confirmParticipants = () => {
     document.getElementById('answer-a').textContent = q.choices.A;
     document.getElementById('answer-b').textContent = q.choices.B;
     document.getElementById('answer-c').textContent = q.choices.C;
+  };
+
+  const showFateCard = (card) => {
+    document.getElementById('fate-card-title').textContent = card.title;
+    document.getElementById('fate-card-text').textContent = card.text;
+    const a = card.choices[0]?.label || '';
+    const b = card.choices[1]?.label || '';
+    const c = card.choices[2]?.label || '';
+    document.getElementById('fate-a-text').textContent = a;
+    document.getElementById('fate-b-text').textContent = b;
+    document.getElementById('fate-c-text').textContent = c;
   };
 
   const showResult = (res) => {
@@ -266,6 +288,7 @@ const confirmParticipants = () => {
     showQuestion,
     showResult,
     showFailure,
+    showFateCard,
     showFateResult,
     showParticipantEntry,
     adjustParticipantCount,


### PR DESCRIPTION
## Summary
- fix participant flavor text not showing
- show Fate Card screen when "Tempt Fate" is chosen
- apply fate card options and track active effects
- list active fate cards in the lobby

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68785327fe988332b5aeebe904f4dfe2