### PR TITLE
Randomize question answer order

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -27,3 +27,4 @@
 - Restored thread and category functions so pull/cut/weave buttons operate again.
 - Adjusted cut thread to end a round without loss so players can escape safely.
 - Implemented fate card display and lobby updates for active effects.
+- Randomized answer order per question to keep players guessing.

--- a/state.js
+++ b/state.js
@@ -27,6 +27,7 @@ const State = (() => {
     activeRoundEffects: [],
     currentFateCard: null,
     currentQuestion: null,
+    currentAnswers: [],
     notWrongCount: 0,
     currentCategory: 'Mind, Past',
     divinations: []
@@ -69,6 +70,7 @@ const State = (() => {
         activeRoundEffects: [],
         currentFateCard: null,
         currentQuestion: null,
+        currentAnswers: [],
         notWrongCount: 0,
         currentCategory: 'Mind, Past',
         divinations: []
@@ -83,6 +85,7 @@ const State = (() => {
     gameState.activeRoundEffects = [];
     gameState.currentFateCard = null;
     gameState.currentCategory = 'Mind, Past';
+    gameState.currentAnswers = [];
   };
 
   const endRound = (outcome = 'lose') => {
@@ -182,6 +185,13 @@ const State = (() => {
     console.log("Resolving round effects...", gameState.activeRoundEffects);
   };
 
+  const shuffleArray = (arr) => {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+  };
+
 
   // --- Question Logic ---
   const getNextQuestion = () => {
@@ -220,7 +230,9 @@ const State = (() => {
     const idx = Math.floor(Math.random() * available.length);
     const q = available[idx];
     gameState.currentQuestion = q;
-    return q;
+    gameState.currentAnswers = q.answers.slice();
+    shuffleArray(gameState.currentAnswers);
+    return { ...q, answers: gameState.currentAnswers };
   };
 
   const evaluateAnswer = (choice) => {
@@ -243,7 +255,7 @@ const State = (() => {
     gameState.answeredQuestionIds.add(question.questionId);
     const idxMap = { A: 0, B: 1, C: 2 };
     const idx = idxMap[choice] ?? 0;
-    const selected = question.answers[idx];
+    const selected = gameState.currentAnswers[idx];
     const cls = selected.answerClass;
 
     let isCorrect = false;


### PR DESCRIPTION
## Summary
- shuffle answers when serving questions
- track randomized answers in game state
- adjust evaluation to use shuffled positions
- log gameplay enhancement

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68785898ad808332a312c08edf654ad9