### PR TITLE
Fix fate card activation and round effects

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -28,3 +28,4 @@
 - Adjusted cut thread to end a round without loss so players can escape safely.
 - Implemented fate card display and lobby updates for active effects.
 - Randomized answer order per question to keep players guessing.
+- Integrated fate card effects with switch logic so drawn cards alter the next round.


### PR DESCRIPTION
## Summary
- add consolidated Fate Deck and track pending/active cards
- activate pending fate cards at start of round
- ensure only one fate card can be drawn at a time
- apply fate card effects during answer evaluation
- log improvement

## Testing
- `npm install`
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68785d79a4588332918d44f9df767a10