### PR TITLE
Fix fate card id mismatches

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -30,3 +30,4 @@
 - Randomized answer order per question to keep players guessing.
 - Integrated fate card effects with switch logic so drawn cards alter the next round.
 - Loaded external fate-cards.json and preserved round points when escaping.
+- Aligned fate card IDs between defaults and external file for consistent behavior when loading fails.

--- a/state.js
+++ b/state.js
@@ -15,7 +15,7 @@ const State = (() => {
     { id: "DYN001", type: 'DYN', text: "Whispers of Doubt: The next 'Wrong' answer costs an extra Thread." },
     { id: "DYN002", type: 'DYN', text: "Sudden Clarity: The first 'Revelatory' answer this round awards bonus points." },
     { id: "DYN003", type: 'DYN', text: "Shared Burden: If the Thread frays, all players feel the chill." },
-    { id: "DYN004", type: 'DYN', text: "Scholar's Boon: Your knowledge protects you. Gain +1 Thread at the start of this round." }
+    { id: "DYN005", type: 'DYN', text: "Scholar's Boon: Your knowledge protects you. Gain +1 Thread at the start of this round." }
   ];
   let fateCardDeck = [];
   let divinationDeck = [];
@@ -106,7 +106,7 @@ const State = (() => {
 
     // Activate any pending fate card for this round
     gameState.activeFateCard = gameState.pendingFateCard;
-    if (gameState.activeFateCard && gameState.activeFateCard.id === 'DYN004') {
+    if (gameState.activeFateCard && gameState.activeFateCard.id === 'DYN005') {
       gameState.thread++; // Scholar's Boon immediate effect
     }
     gameState.pendingFateCard = null;


### PR DESCRIPTION
## Summary
- sync fallback fate deck IDs with `fate-cards.json`
- trigger Scholar's Boon thread bonus on `DYN005`
- log alignment of fate card IDs

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68786a16ac3883329141df859b994994