### PR TITLE
Fix round init bug & add question stub

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -32,3 +32,4 @@
 - Loaded external fate-cards.json and preserved round points when escaping.
 - Expanded fate mechanics with predictions, modifiers, tallies, and power-ups for richer round outcomes.
 - Aligned fate card IDs between defaults and external file for consistent behavior when loading fails.
+- Fixed object spread typos and removed duplicate if block; replaced missing wood texture with gradient to prevent load errors.

--- a/questions/questions.json
+++ b/questions/questions.json
@@ -123,7 +123,39 @@
         "explanation": "Incorrect. you don’t need to see in order to read braille, eyes closed or open, you can still read.",
         "changePoint": 0,
         "changeThread": -1,
-        "traitChanges": { "X": -1, "Y": -1, "Z": 0 }
+    "traitChanges": { "X": -1, "Y": -1, "Z": 0 }
+      }
+    ]
+  },
+  {
+    "questionId": 5,
+    "category": "Soul",
+    "title": "Deep Freeze",
+    "text": "Which emotion can chill the spirit?",
+    "answers": [
+      {
+        "text": "Fear",
+        "answerClass": "Typical",
+        "explanation": "Fear grips you with an icy hand.",
+        "changePoint": 2,
+        "changeThread": 0,
+        "traitChanges": { "X": 0, "Y": 0, "Z": 1 }
+      },
+      {
+        "text": "Joy",
+        "answerClass": "Revelatory",
+        "explanation": "Even joy can freeze when it feels out of place.",
+        "changePoint": 1,
+        "changeThread": 1,
+        "traitChanges": { "X": 1, "Y": 1, "Z": 0 }
+      },
+      {
+        "text": "Hunger",
+        "answerClass": "Wrong",
+        "explanation": "Hunger is a gnawing heat, not a chill.",
+        "changePoint": 0,
+        "changeThread": -1,
+        "traitChanges": { "X": -1, "Y": 0, "Z": -1 }
       }
     ]
   }

--- a/state.js
+++ b/state.js
@@ -112,8 +112,6 @@ const State = (() => {
 
     // Activate any pending fate card for this round
     gameState.activeFateCard = gameState.pendingFateCard;
-    if (gameState.activeFateCard &&
-        (gameState.activeFateCard.id === 'DYN005' || gameState.activeFateCard.id === 'DYN004')) {
     if (gameState.activeFateCard && gameState.activeFateCard.id === 'DYN005') {
       gameState.thread++; // Scholar's Boon immediate effect
     }

--- a/style.css
+++ b/style.css
@@ -23,7 +23,7 @@ body {
   color: var(--text-color);
   font-family: var(--body-font);
   overflow: hidden;
-  background-image: url('woodgrain-texture.jpg');
+  background-image: linear-gradient(45deg, #3e2b16, #1a120b);
   background-size: cover;
   margin: 0;
 }


### PR DESCRIPTION
## Summary
- fix syntax in startNewRound and remove duplicated fate check
- replace missing wood texture with gradient background
- add sample Soul question to stub deck
- log the update

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687909ac51908332bd866c00b3e04579