### PR TITLE
Initialize Fate loader and schema

### DIFF
--- a/__tests__/fate-load.test.js
+++ b/__tests__/fate-load.test.js
@@ -1,0 +1,5 @@
+const { DECK } = require('../src/fate/loadDeck');
+
+test('fate deck loads', () => {
+  expect(DECK.length).toBeGreaterThan(0);
+});

--- a/src/fate/loadDeck.js
+++ b/src/fate/loadDeck.js
@@ -1,0 +1,19 @@
+const { FateCard } = require('./schema');
+const cards = require('../../fate-cards.json');
+
+const sanitize = (card) => ({
+  id: card.id,
+  title: card.title,
+  text: card.text,
+  choices: (card.choices || []).map((ch) => {
+    const eff = ch.effect;
+    if (eff && eff.type === 'IMMEDIATE_SCORE' && typeof eff.value === 'number') {
+      return { label: ch.label, effect: { type: 'IMMEDIATE_SCORE', value: eff.value } };
+    }
+    return { label: ch.label };
+  })
+});
+
+const DECK = cards.map((c) => FateCard.parse(sanitize(c)));
+
+module.exports = { DECK };

--- a/src/fate/schema.js
+++ b/src/fate/schema.js
@@ -1,0 +1,20 @@
+const { z } = require('zod');
+
+const Effect = z.object({
+  type: z.literal('IMMEDIATE_SCORE'),
+  value: z.number()
+});
+
+const Choice = z.object({
+  label: z.string(),
+  effect: Effect.optional()
+});
+
+const FateCard = z.object({
+  id: z.string(),
+  title: z.string(),
+  text: z.string(),
+  choices: z.array(Choice)
+});
+
+module.exports = { Effect, Choice, FateCard };


### PR DESCRIPTION
## Summary
- add zod schema for minimal Fate cards
- load and sanitize Fate deck from JSON
- test Fate deck loading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68796acd2fc08332a482f7f2d08fe05c