### PR TITLE
Fate-engine refactor

### DIFF
--- a/__tests__/fate.test.js
+++ b/__tests__/fate.test.js
@@ -1,0 +1,19 @@
+const Fate = require('../src/fate/fateEngine');
+const cards = require('../fate-cards.json');
+
+test('DYN001 wager adds score per C answer', () => {
+  let card;
+  do { card = Fate.draw(); } while (card.id !== 'DYN001');
+  // choose Wait option (index 1)
+  Fate.choose(1);
+  const res = Fate.resolveRound({ A: 0, B: 0, C: 2 }, true);
+  expect(res.roundScoreDelta).toBe(2);
+});
+
+test('DYN004 tally table doubles round score when no Cs', () => {
+  let card;
+  do { card = Fate.draw(); } while (card.id !== 'DYN004');
+  Fate.choose(0);
+  const res = Fate.resolveRound({ A: 2, B: 1, C: 0 }, true);
+  expect(res.roundScoreMultiplier).toBe(2);
+});

--- a/__tests__/smoke.test.js
+++ b/__tests__/smoke.test.js
@@ -45,6 +45,7 @@ describe('basic playthrough', () => {
     };
     inject(fs.readFileSync(path.join(__dirname, '../state.js'), 'utf8'));
     inject(fs.readFileSync(path.join(__dirname, '../ui.js'), 'utf8'));
+    inject(fs.readFileSync(path.join(__dirname, '../src/fate/fateEngine.js'), 'utf8'));
     inject(fs.readFileSync(path.join(__dirname, '../script.js'), 'utf8'));
     wnd.document.dispatchEvent(new wnd.Event('DOMContentLoaded'));
     jest.runAllTimers();

--- a/fate-cards.json
+++ b/fate-cards.json
@@ -22,7 +22,8 @@
           "reward": { "type": "SCORE", "value": 1 },
           "flavorText": "You let the moth spiral towards the flame. You feel a strange connection to its fate, tied to your future choices."
         }
-      }
+      },
+      { "label": "Ignore" }
     ]
   },
   {
@@ -61,9 +62,9 @@
     "rarity": "Uncommon",
     "tags": ["Gamble", "Consequence", "Pact"],
     "text": "You accept the Tallyman's Gambit. Each time you answer 'C' this round, a tally is marked. The final count will determine your fate.",
-    "choices": [
-      { "label": "Accept", "effect": { "type": "TALLY_ANSWERS", "target": "C" } }
-    ],
+      "choices": [
+        { "label": "Accept", "effect": { "type": "TALLY_TABLE", "target": "C", "table": { "0": { "type": "DOUBLE_ROUND_SCORE" } } } }
+      ],
     "duration": "round",
     "resolveAt": "endOfRound"
   },

--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -38,3 +38,4 @@
 - Fixed syntax error in State and skipped Playwright downloads for smoother CI
 - Improved mobile layout with media query and dynamic transition radius; detached welcome key listeners so arrows no longer scroll mid-game.
 
+- Refactored fate system into new module with schema validation; added UI hooks and tests for dynamic cards.

--- a/src/fate/fateEngine.js
+++ b/src/fate/fateEngine.js
@@ -1,0 +1,80 @@
+(function (global) {
+  const { FateCard } = require('./schema');
+  const deckData = require('../../fate-cards.json');
+  const { z } = require('zod');
+
+  const DeckSchema = z.array(FateCard);
+  const DYN_DECK = DeckSchema.parse(deckData);
+
+  let currentCard = null;
+  let storedEffects = [];
+  let immediateScore = 0;
+
+  function draw() {
+    currentCard = DYN_DECK[Math.floor(Math.random() * DYN_DECK.length)];
+    return currentCard;
+  }
+
+  function getButtonLabels() {
+    if (!currentCard) return ['', '', ''];
+    const labels = currentCard.choices.map(c => c.label);
+    while (labels.length < 3) labels.push('');
+    return labels.slice(0, 3);
+  }
+
+  function choose(index) {
+    if (!currentCard) return null;
+    const choice = currentCard.choices[index];
+    if (!choice) { currentCard = null; return null; }
+    const eff = choice.effect;
+    if (eff) {
+      if (eff.type === 'IMMEDIATE_SCORE') {
+        immediateScore += eff.value;
+      } else if (eff.type === 'ADD_CARD_TO_DECK') {
+        if (eff.card) DYN_DECK.push(eff.card);
+      } else {
+        storedEffects.push(eff);
+      }
+    }
+    currentCard = null;
+    return eff && eff.flavorText ? eff.flavorText : null;
+  }
+
+  function resolveRound(tally, won) {
+    let scoreDelta = immediateScore;
+    let roundScoreDelta = 0;
+    let roundScoreMultiplier = 1;
+
+    storedEffects.forEach(eff => {
+      if (eff.type === 'APPLY_WAGER') {
+        const t = eff.target.split('-').pop().toUpperCase();
+        const count = tally[t] || 0;
+        if (eff.reward && eff.reward.type === 'SCORE') {
+          roundScoreDelta += eff.reward.value * count;
+        }
+      } else if (eff.type === 'TALLY_TABLE') {
+        const count = tally[eff.target] || 0;
+        if (eff.table && eff.table[count]) {
+          const reward = eff.table[count];
+          if (reward.type === 'DOUBLE_ROUND_SCORE') {
+            roundScoreMultiplier *= 2;
+          } else if (reward.type === 'SCORE') {
+            scoreDelta += reward.value;
+          }
+        }
+      }
+    });
+
+    storedEffects = [];
+    immediateScore = 0;
+    return { scoreDelta, roundScoreDelta, roundScoreMultiplier };
+  }
+
+  const api = { draw, getButtonLabels, choose, resolveRound };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  } else {
+    global.Fate = api;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/src/fate/schema.js
+++ b/src/fate/schema.js
@@ -1,9 +1,8 @@
 const { z } = require('zod');
 
 const Effect = z.object({
-  type: z.literal('IMMEDIATE_SCORE'),
-  value: z.number()
-});
+  type: z.string()
+}).catchall(z.any());
 
 const Choice = z.object({
   label: z.string(),
@@ -14,7 +13,7 @@ const FateCard = z.object({
   id: z.string(),
   title: z.string(),
   text: z.string(),
-  choices: z.array(Choice)
+  choices: z.array(Choice).max(3)
 });
 
 module.exports = { Effect, Choice, FateCard };

--- a/state.js
+++ b/state.js
@@ -45,10 +45,10 @@ const State = (() => {
     currentCategory: 'Mind, Past',
     divinations: [],
     roundAnswerTally: { A: 0, B: 0, C: 0 },
-    activePowerUps: []
+    activePowerUps: [],
+    answeredThisRound: []
   };
 
-  // --- Data Loading ---
   const loadData = async () => {
     try {
       const [questionsRes, fateCardsRes, divinationsRes] = await Promise.all([
@@ -106,6 +106,7 @@ const State = (() => {
     gameState.activeRoundEffects = [];
     gameState.roundAnswerTally = { A: 0, B: 0, C: 0 };
     gameState.activePowerUps = [];
+    gameState.answeredThisRound = [];
     gameState.currentFateCard = null;
     gameState.currentCategory = 'Mind, Past';
     gameState.currentAnswers = [];
@@ -409,6 +410,15 @@ const State = (() => {
     gameState.roundScore = 0;
   };
 
+  const recordAnswer = (qid, letter) => {
+    gameState.answeredThisRound.push({ qid, letter });
+  };
+
+  const resetRound = () => {
+    gameState.answeredThisRound = [];
+    gameState.activeRoundEffects = [];
+  };
+
   const drawDivination = () => {
     if (divinationDeck.length === 0) return null;
     const line = divinationDeck[Math.floor(Math.random() * divinationDeck.length)];
@@ -467,6 +477,8 @@ const State = (() => {
     hasWonGame,
     isOutOfLives,
     saveGame,
-    loadGame
+    loadGame,
+    recordAnswer,
+    resetRound,
   };
 })();

--- a/ui.js
+++ b/ui.js
@@ -183,6 +183,15 @@ const UI = (() => {
       }
     });
   };
+
+  const setButtonLabels = (arr) => {
+    ['btn1', 'btn2', 'btn3'].forEach((id, i) => {
+      const btn = buttons[id];
+      const label = arr[i] || '';
+      btn.querySelector('.button-label').innerText = label;
+      btn.disabled = label === '';
+    });
+  };
 // Inside the UI IIFE
 const participantCountDisplay = document.getElementById('participant-count-display');
 const flavorLine = document.getElementById('participant-flavor');
@@ -265,6 +274,10 @@ const confirmParticipants = () => {
     document.getElementById('fate-c-text').textContent = c;
   };
 
+  const showFate = (card) => {
+    showFateCard(card);
+  };
+
   const showResult = (res) => {
     document.getElementById('result-header').textContent = res.correct ? "Correct" : "Incorrect";
     document.getElementById('result-question').textContent = res.question;
@@ -289,8 +302,10 @@ const confirmParticipants = () => {
     configureButtons,
     updateDisplayValues,
     showQuestion,
+    setButtonLabels,
     showResult,
     showFailure,
+    showFate,
     showFateCard,
     showFateResult,
     showParticipantEntry,


### PR DESCRIPTION
## Summary
- build a new fate engine module and schema
- update data for DYN001 and DYN004
- add helper methods in state and hook up UI buttons
- extend smoke test and add new fate tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879711412fc83328fa032742f60fe00