### PR TITLE
Fix Tempt Fate with ES modules

### DIFF
--- a/__tests__/fate.test.js
+++ b/__tests__/fate.test.js
@@ -1,5 +1,22 @@
-const Fate = require('../src/fate/fateEngine');
+const fs = require('fs');
+const path = require('path');
+
+
+let Fate;
 const cards = require('../fate-cards.json');
+
+beforeAll(() => {
+  let code = fs.readFileSync(path.join(__dirname, '../src/fate/fateEngine.js'), 'utf8');
+  code = code.replace("import { z } from 'zod';", "const { z } = require('zod');")
+             .replace("import { FateCard } from './schema.js';", "const { FateCard } = require('../src/fate/schema.js');")
+             .replace(/import deckData from '\.\.\/\.\.\/fate-cards.json' assert { type: 'json' };/, "const deckData = require('../fate-cards.json');")
+             .replace(/export function /g, 'function ');
+  code += '\nmodule.exports = { draw, getButtonLabels, choose, resolveRound };';
+  const mod = { exports: {} };
+  const func = new Function('require','module','exports', code);
+  func(require, mod, mod.exports);
+  Fate = mod.exports;
+});
 
 test('DYN001 wager adds score per C answer', () => {
   let card;

--- a/__tests__/smoke.test.js
+++ b/__tests__/smoke.test.js
@@ -38,14 +38,15 @@ describe('basic playthrough', () => {
     const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
     dom = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost' });
     const wnd = dom.window;
-    const inject = (code) => {
+    const inject = (code, type = 'text/javascript') => {
       const s = wnd.document.createElement('script');
       s.textContent = code;
+      s.type = type;
       wnd.document.body.appendChild(s);
     };
     inject(fs.readFileSync(path.join(__dirname, '../state.js'), 'utf8'));
     inject(fs.readFileSync(path.join(__dirname, '../ui.js'), 'utf8'));
-    inject(fs.readFileSync(path.join(__dirname, '../src/fate/fateEngine.js'), 'utf8'));
+    inject(fs.readFileSync(path.join(__dirname, '../src/fate/fateEngine.js'), 'utf8'), 'module');
     inject(fs.readFileSync(path.join(__dirname, '../script.js'), 'utf8'));
     wnd.document.dispatchEvent(new wnd.Event('DOMContentLoaded'));
     jest.runAllTimers();

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <!-- Scripts are deferred to ensure elements exist before execution -->
     <script src="state.js" defer></script>
     <script src="ui.js" defer></script>
-    <script src="src/fate/fateEngine.js" defer></script>
+    <script type="module" src="src/fate/fateEngine.js"></script>
     <script src="script.js" defer></script>
 </head>
 <body>

--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -41,3 +41,4 @@
 - Refactored fate system into new module with schema validation; added UI hooks and tests for dynamic cards.
 - Injected fate engine script into HTML so 'Tempt Fate' draws cards correctly.
 - Applied fate engine results to game state and show summary after each round.
+- Converted fate engine to ES module and updated HTML loader for browser compatibility.

--- a/src/fate/fateEngine.js
+++ b/src/fate/fateEngine.js
@@ -1,80 +1,70 @@
-(function (global) {
-  const { FateCard } = require('./schema');
-  const deckData = require('../../fate-cards.json');
-  const { z } = require('zod');
+import { z } from 'zod';
+import { FateCard } from './schema.js';
+import deckData from '../../fate-cards.json' assert { type: 'json' };
 
-  const DeckSchema = z.array(FateCard);
-  const DYN_DECK = DeckSchema.parse(deckData);
+const DeckSchema = z.array(FateCard);
+const DYN_DECK = DeckSchema.parse(deckData);
 
-  let currentCard = null;
-  let storedEffects = [];
-  let immediateScore = 0;
+let currentCard = null;
+let storedEffects = [];
+let immediateScore = 0;
 
-  function draw() {
-    currentCard = DYN_DECK[Math.floor(Math.random() * DYN_DECK.length)];
-    return currentCard;
-  }
+export function draw() {
+  currentCard = DYN_DECK[Math.floor(Math.random() * DYN_DECK.length)];
+  return currentCard;
+}
 
-  function getButtonLabels() {
-    if (!currentCard) return ['', '', ''];
-    const labels = currentCard.choices.map(c => c.label);
-    while (labels.length < 3) labels.push('');
-    return labels.slice(0, 3);
-  }
+export function getButtonLabels() {
+  if (!currentCard) return ['', '', ''];
+  const labels = currentCard.choices.map(c => c.label || '');
+  while (labels.length < 3) labels.push('');
+  return labels.slice(0, 3);
+}
 
-  function choose(index) {
-    if (!currentCard) return null;
-    const choice = currentCard.choices[index];
-    if (!choice) { currentCard = null; return null; }
-    const eff = choice.effect;
-    if (eff) {
-      if (eff.type === 'IMMEDIATE_SCORE') {
-        immediateScore += eff.value;
-      } else if (eff.type === 'ADD_CARD_TO_DECK') {
-        if (eff.card) DYN_DECK.push(eff.card);
-      } else {
-        storedEffects.push(eff);
+export function choose(index) {
+  if (!currentCard) return null;
+  const choice = currentCard.choices[index];
+  if (!choice?.effect) { currentCard = null; return null; }
+  applyEffect(choice.effect);
+  currentCard = null;
+  return choice.effect?.flavorText || null;
+}
+
+export function resolveRound(tally, won) {
+  let scoreDelta = immediateScore;
+  let roundScoreDelta = 0;
+  let roundScoreMultiplier = 1;
+
+  storedEffects.forEach(eff => {
+    if (eff.type === 'APPLY_WAGER') {
+      const t = eff.target.split('-').pop().toUpperCase();
+      const count = tally[t] || 0;
+      if (eff.reward && eff.reward.type === 'SCORE') {
+        roundScoreDelta += eff.reward.value * count;
+      }
+    } else if (eff.type === 'TALLY_TABLE') {
+      const count = tally[eff.target] || 0;
+      if (eff.table && eff.table[count]) {
+        const reward = eff.table[count];
+        if (reward.type === 'DOUBLE_ROUND_SCORE') {
+          roundScoreMultiplier *= 2;
+        } else if (reward.type === 'SCORE') {
+          scoreDelta += reward.value;
+        }
       }
     }
-    currentCard = null;
-    return eff && eff.flavorText ? eff.flavorText : null;
-  }
+  });
 
-  function resolveRound(tally, won) {
-    let scoreDelta = immediateScore;
-    let roundScoreDelta = 0;
-    let roundScoreMultiplier = 1;
+  storedEffects = [];
+  immediateScore = 0;
+  return { scoreDelta, roundScoreDelta, roundScoreMultiplier };
+}
 
-    storedEffects.forEach(eff => {
-      if (eff.type === 'APPLY_WAGER') {
-        const t = eff.target.split('-').pop().toUpperCase();
-        const count = tally[t] || 0;
-        if (eff.reward && eff.reward.type === 'SCORE') {
-          roundScoreDelta += eff.reward.value * count;
-        }
-      } else if (eff.type === 'TALLY_TABLE') {
-        const count = tally[eff.target] || 0;
-        if (eff.table && eff.table[count]) {
-          const reward = eff.table[count];
-          if (reward.type === 'DOUBLE_ROUND_SCORE') {
-            roundScoreMultiplier *= 2;
-          } else if (reward.type === 'SCORE') {
-            scoreDelta += reward.value;
-          }
-        }
-      }
-    });
+function applyEffect(eff) {
+  if (eff.type === 'IMMEDIATE_SCORE') immediateScore += eff.value;
+  else if (eff.type === 'ADD_CARD_TO_DECK' && eff.card) DYN_DECK.push(eff.card);
+  else storedEffects.push(eff);
+}
 
-    storedEffects = [];
-    immediateScore = 0;
-    return { scoreDelta, roundScoreDelta, roundScoreMultiplier };
-  }
-
-  const api = { draw, getButtonLabels, choose, resolveRound };
-
-  if (typeof module !== 'undefined' && module.exports) {
-    module.exports = api;
-  } else {
-    global.Fate = api;
-  }
-})(typeof window !== 'undefined' ? window : globalThis);
+// expose to global for non-module script.js
+if (typeof window !== 'undefined') window.Fate = { draw, getButtonLabels, choose, resolveRound };


### PR DESCRIPTION
## Summary
- convert fate engine to ES module and expose functions globally
- load fate engine with `<script type="module">`
- adjust tests for module loading
- log the change in improvements log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68799386d5f883329060db191aa0f88a