### PR TITLE
Fix browser import for fate engine

### DIFF
--- a/__tests__/fate.test.js
+++ b/__tests__/fate.test.js
@@ -7,9 +7,7 @@ const cards = require('../fate-cards.json');
 
 beforeAll(() => {
   let code = fs.readFileSync(path.join(__dirname, '../src/fate/fateEngine.js'), 'utf8');
-  code = code.replace("import { z } from 'zod';", "const { z } = require('zod');")
-             .replace("import { FateCard } from './schema.js';", "const { FateCard } = require('../src/fate/schema.js');")
-             .replace(/import deckData from '\.\.\/\.\.\/fate-cards.json' assert { type: 'json' };/, "const deckData = require('../fate-cards.json');")
+  code = code.replace(/import deckData from '\.\.\/\.\.\/fate-cards.json' assert { type: 'json' };/, "const deckData = require('../fate-cards.json');")
              .replace(/export function /g, 'function ');
   code += '\nmodule.exports = { draw, getButtonLabels, choose, resolveRound };';
   const mod = { exports: {} };

--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -42,3 +42,4 @@
 - Injected fate engine script into HTML so 'Tempt Fate' draws cards correctly.
 - Applied fate engine results to game state and show summary after each round.
 - Converted fate engine to ES module and updated HTML loader for browser compatibility.
+- Simplified fate engine validation and removed zod import for direct browser loading.

--- a/src/fate/fateEngine.js
+++ b/src/fate/fateEngine.js
@@ -1,9 +1,9 @@
-import { z } from 'zod';
-import { FateCard } from './schema.js';
 import deckData from '../../fate-cards.json' assert { type: 'json' };
 
-const DeckSchema = z.array(FateCard);
-const DYN_DECK = DeckSchema.parse(deckData);
+// minimal runtime validation so browser doesn't need extra deps
+const DYN_DECK = Array.isArray(deckData)
+  ? deckData.filter(c => c && c.id && c.choices)
+  : [];
 
 let currentCard = null;
 let storedEffects = [];


### PR DESCRIPTION
## Summary
- strip zod from fateEngine to avoid browser import errors
- adjust unit test harness for new module shape
- log simplification in project improvements

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6879a2992c308332814b6fa044222d8a