### PR TITLE
Fix CDN import for Fate engine

### DIFF
--- a/__tests__/fate.test.js
+++ b/__tests__/fate.test.js
@@ -7,7 +7,8 @@ const cards = require('../fate-cards.json');
 
 beforeAll(() => {
   let code = fs.readFileSync(path.join(__dirname, '../src/fate/fateEngine.js'), 'utf8');
-  code = code.replace(/import deckData from '\.\.\/\.\.\/fate-cards.json' assert { type: 'json' };/, "const deckData = require('../fate-cards.json');")
+  code = code.replace("import { z } from 'https://cdn.jsdelivr.net/npm/zod/+esm';", "const { z } = require('zod');")
+             .replace(/import deckData from '\.\.\/\.\.\/fate-cards.json' assert { type: 'json' };/, "const deckData = require('../fate-cards.json');")
              .replace(/export function /g, 'function ');
   code += '\nmodule.exports = { draw, getButtonLabels, choose, resolveRound };';
   const mod = { exports: {} };

--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -44,3 +44,4 @@
 - Converted fate engine to ES module and updated HTML loader for browser compatibility.
 - Simplified fate engine validation and removed zod import for direct browser loading.
 - Loaded Zod from CDN for optional browser validation, preparing future state checks.
+- Integrated CDN import for fate engine validation so browser module resolves without bundler.

--- a/src/fate/fateEngine.js
+++ b/src/fate/fateEngine.js
@@ -1,9 +1,20 @@
+import { z } from 'https://cdn.jsdelivr.net/npm/zod/+esm';
 import deckData from '../../fate-cards.json' assert { type: 'json' };
 
-// minimal runtime validation so browser doesn't need extra deps
-const DYN_DECK = Array.isArray(deckData)
-  ? deckData.filter(c => c && c.id && c.choices)
-  : [];
+const Choice = z.object({
+  label: z.string().optional(),
+  effect: z.any().optional()
+});
+
+const FateCard = z.object({
+  id: z.string(),
+  title: z.string(),
+  text: z.string(),
+  choices: z.array(Choice).max(3)
+});
+
+const DeckSchema = z.array(FateCard);
+const DYN_DECK = DeckSchema.parse(deckData);
 
 let currentCard = null;
 let storedEffects = [];


### PR DESCRIPTION
## Summary
- import Zod from CDN in `fateEngine.js`
- adjust unit test mock replacement for the CDN import
- log the improvement

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a48b7cbdc833297c6e318a335159a