### PR TITLE
Add QuestionEngine and tiered question data

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -46,3 +46,4 @@
 - Loaded Zod from CDN for optional browser validation, preparing future state checks.
 - Integrated CDN import for fate engine validation so browser module resolves without bundler.
 - Removed duplicate DYN005 thread bonus to keep start of round balanced.
+- Added QuestionEngine module with tiered questions for modular trivia management.

--- a/src/data/questions.json
+++ b/src/data/questions.json
@@ -1,0 +1,272 @@
+{
+  "questions": [
+    /* ---------- Tier 1 : IDs 101-120  ---------- */
+    {
+      "questionId": 101,
+      "category": "Mind",
+      "difficultyTier": "Tier1",
+      "title": "The Shape of Things",
+      "text": "Which of these has 3 sides?",
+      "answers": [
+        { "text": "Triangle", "answerClass": "Typical",
+          "explanation": "Of course you’d say that. And you're not wrong. A triangle has three sides." },
+        { "text": "Square",   "answerClass": "Revelatory",
+          "explanation": "No, a Tri- oh. That is also right. A square has three sides... and one more." },
+        { "text": "Circle",   "answerClass": "Wrong",
+          "explanation": "Not even close. A circle is a curve without any sides." }
+      ]
+    },
+    {
+      "questionId": 102,
+      "category": "Mind",
+      "difficultyTier": "Tier1",
+      "title": "Capital Offense",
+      "text": "What is the capital of France?",
+      "answers": [
+        { "text": "Paris",       "answerClass": "Typical",
+          "explanation": "We thought you’d say that. Paris is the capital city of France." },
+        { "text": "The letter F", "answerClass": "Revelatory",
+          "explanation": "Well, hmm. Yes, 'F' is the capital letter in 'France'." },
+        { "text": "Versailles",  "answerClass": "Wrong",
+          "explanation": "Versailles was once the capital, but is not today." }
+      ]
+    },
+    {
+      "questionId": 103,
+      "category": "Mind",
+      "difficultyTier": "Tier1",
+      "title": "No It Isn’t",
+      "text": "What is between 1 and 3?",
+      "answers": [
+        { "text": "2",   "answerClass": "Typical",
+          "explanation": "That’s what the last one said. Numerically, 2 lies between 1 and 3." },
+        { "text": "and", "answerClass": "Revelatory",
+          "explanation": "Great. Right. The word 'and' is between the numerals." },
+        { "text": "what","answerClass": "Wrong",
+          "explanation": "Incorrect. 'What' is not between the numbers." }
+      ]
+    },
+    {
+      "questionId": 104,
+      "category": "Mind",
+      "difficultyTier": "Tier1",
+      "title": "Merry Unbirthday",
+      "text": "How many birthdays does the average person have?",
+      "answers": [
+        { "text": "About Fifty", "answerClass": "Typical",
+          "explanation": "That’s right, on average  a person will have 50 such anniversaries in a modern lifespan." },
+        { "text": "One",         "answerClass": "Revelatory",
+          "explanation": "Ah, a literalist. We like that. You are only born once; the rest are just parties." },
+        { "text": "Depends on how many friends they have", "answerClass": "Wrong",
+          "explanation": "A charming thought, but incorrect. Parties don't change the number of times you were born." }
+      ]
+    },
+    {
+      "questionId": 105,
+      "category": "Body",
+      "difficultyTier": "Tier1",
+      "title": "Eye Witness",
+      "text": "What can’t you do if your eyes are closed?",
+      "answers": [
+        { "text": "See",  "answerClass": "Typical",
+          "explanation": "You cannot see with your eyes shut. But it depends on what you were trying to see… or avoid." },
+        { "text": "Close them", "answerClass": "Revelatory",
+          "explanation": "We figured you’d say that. You cannot perform an action on something already in that state." },
+        { "text": "Read", "answerClass": "Wrong",
+          "explanation": "A flawed assumption. Braille can be read with your eyes closed." }
+      ]
+    },
+    {
+      "questionId": 106,
+      "category": "Mind",
+      "difficultyTier": "Tier1",
+      "title": "Just the Two of Us",
+      "text": "What does 2 and 2 make?",
+      "answers": [
+        { "text": "Four",       "answerClass": "Typical",
+          "explanation": "Math class paid off. Correct, 2 + 2 = 4." },
+        { "text": "Twenty-Two", "answerClass": "Revelatory",
+          "explanation": "You saw the loophole. When concatenated, the numerals '2' and '2' form 22." },
+        { "text": "Eight",      "answerClass": "Wrong",
+          "explanation": "Oh, wow—you’ll have to show us how you got that." }
+      ]
+    },
+    {
+      "questionId": 107,
+      "category": "Mind",
+      "difficultyTier": "Tier1",
+      "title": "I Know This One",
+      "text": "Which month has 28 days?",
+      "answers": [
+        { "text": "February",   "answerClass": "Typical",
+          "explanation": "The one everyone remembers. February typically has exactly 28 days." },
+        { "text": "All of them","answerClass": "Revelatory",
+          "explanation": "You didn't fall for the trap. Every single month has at least 28 days." },
+        { "text": "None of them","answerClass": "Wrong",
+          "explanation": "Incorrect. Check your calendar again." }
+      ]
+    },
+    {
+      "questionId": 108,
+      "category": "Body",
+      "difficultyTier": "Tier1",
+      "title": "Clovers and Blue Moons",
+      "text": "What’s at the end of a rainbow?",
+      "answers": [
+        { "text": "A pot of gold", "answerClass": "Typical",
+          "explanation": "Chasing myths, are we? Folklore says a leprechaun’s treasure lies at the end." },
+        { "text": "Violet",        "answerClass": "Revelatory",
+          "explanation": "A mind of science. In physics, the visible spectrum ends at violet." },
+        { "text": "Rainbows aren’t real.", "answerClass": "Wrong",
+          "explanation": "Is anything? Are we?" }
+      ]
+    },
+    {
+      "questionId": 109,
+      "category": "Soul",
+      "difficultyTier": "Tier1",
+      "title": "What’s in It?",
+      "text": "What did Schrödinger do with his box?",
+      "answers": [
+        { "text": "Ended up inspiring the Many-Worlds interpretation.", "answerClass": "Typical",
+          "explanation": "Causation or correlation? Either way, sure." },
+        { "text": "Tried to illustrate the problem with Quantum Mechanics.", "answerClass": "Revelatory",
+          "explanation": "Schrödinger's experiment was a critique of quantum mechanics, not an endorsement." },
+        { "text": "Killed a cat.", "answerClass": "Wrong",
+          "explanation": "Don't believe the rumors. No cat was harmed in the making of this thought experiment." }
+      ]
+    },
+
+    /* ---------- Tier 2 : IDs 201-220  ---------- */
+    {
+      "questionId": 201,
+      "category": "Mind",
+      "difficultyTier": "Tier2",
+      "title": "Payday",
+      "text": "If you’re told you’ll be paid biweekly, how often do you get paid?",
+      "answers": [
+        { "text": "Every two weeks.",        "answerClass": "Typical",
+          "explanation": "Just like at the office. Most workplaces use 'biweekly' to mean every two weeks." },
+        { "text": "Twice each week.",        "answerClass": "Revelatory",
+          "explanation": "You consulted the dictionary, didn't you? It has two official meanings." },
+        { "text": "Whenever payroll processes the batch.", "answerClass": "Wrong",
+          "explanation": "A cynical take, but not an answer." }
+      ]
+    },
+    {
+      "questionId": 202,
+      "category": "Soul",
+      "difficultyTier": "Tier2",
+      "title": "Styx and Stones",
+      "text": "What is needed when you meet Charon at the River Styx?",
+      "answers": [
+        { "text": "A coin",  "answerClass": "Typical",
+          "explanation": "You remembered the toll. Greek rites demand a coin for the ferryman." },
+        { "text": "Passage", "answerClass": "Revelatory",
+          "explanation": "You see the true need. The coin only buys the journey you require." },
+        { "text": "A heart as light as a feather", "answerClass": "Wrong",
+          "explanation": "Wrong mythology. That's an Egyptian trial, not a Greek one." }
+      ]
+    },
+    {
+      "questionId": 203,
+      "category": "Body",
+      "difficultyTier": "Tier2",
+      "title": "It’s Other People",
+      "text": "In order to leave a room, you must…?",
+      "answers": [
+        { "text": "Exit it.", "answerClass": "Typical",
+          "explanation": "You can try." },
+        { "text": "Enter it.", "answerClass": "Revelatory",
+          "explanation": "Ah, the prerequisite. You cannot leave a room you were never in to begin with." },
+        { "text": "Imagine it.", "answerClass": "Wrong",
+          "explanation": "But what then? What if you can’t… stop imagining it?" }
+      ]
+    },
+    {
+      "questionId": 204,
+      "category": "Body",
+      "difficultyTier": "Tier2",
+      "title": "The Great Divide",
+      "text": "What separates one meal from another?",
+      "answers": [
+        { "text": "Time",  "answerClass": "Typical",
+          "explanation": "The clock rules all. Most people mark meals by time of day." },
+        { "text": "Space", "answerClass": "Revelatory",
+          "explanation": "A very physical answer. Two meals cannot occupy the same space at the same time." },
+        { "text": "Gravity", "answerClass": "Wrong",
+          "explanation": "Incorrect. Gravity acts on all meals; it does not separate them." }
+      ]
+    },
+    {
+      "questionId": 205,
+      "category": "Body",
+      "difficultyTier": "Tier2",
+      "title": "On Your Marx",
+      "text": "How do you prevent the working class from revolting?",
+      "answers": [
+        { "text": "Bread and circuses", "answerClass": "Typical",
+          "explanation": "The classic Roman solution. Pacify the masses with cheap comforts." },
+        { "text": "They can’t revolt if they’re dead", "answerClass": "Revelatory",
+          "explanation": "A chilling thought. But in terms of cold logic: an infallible solution." },
+        { "text": "Give them cake", "answerClass": "Wrong",
+          "explanation": "That's just a rumor—and famously bad advice." }
+      ]
+    },
+    {
+      "questionId": 206,
+      "category": "Body",
+      "difficultyTier": "Tier2",
+      "title": "A Nice Trip",
+      "text": "What is the shortest distance between two points?",
+      "answers": [
+        { "text": "A straight line.", "answerClass": "Typical",
+          "explanation": "Thinking on a flat plane, are we? Correct in Euclidean space." },
+        { "text": "A geodesic",       "answerClass": "Revelatory",
+          "explanation": "You think in curves. On a sphere like Earth, a geodesic is the true shortest path." },
+        { "text": "A circle",         "answerClass": "Wrong",
+          "explanation": "A circle is never the shortest path between two points." }
+      ]
+    },
+    {
+      "questionId": 207,
+      "category": "Soul",
+      "difficultyTier": "Tier2",
+      "title": "Imperial Memory",
+      "text": "Which of these was a Roman Emperor?",
+      "answers": [
+        { "text": "Marcus Aurelius", "answerClass": "Typical",
+          "explanation": "The philosopher-king. He's the one we all like to remember." },
+        { "text": "Caligula",        "answerClass": "Revelatory",
+          "explanation": "The inconvenient truth. He was an emperor, even if we'd rather forget." },
+        { "text": "Julius Caesar",   "answerClass": "Wrong",
+          "explanation": "A common myth. Caesar was a dictator, but he never held the title of emperor." }
+      ]
+    },
+    {
+      "questionId": 208,
+      "category": "Mind",
+      "difficultyTier": "Tier2",
+      "title": "All Cretans",
+      "text": "TBD – please provide final wording & answers",
+      "answers": []
+    },
+    {
+      "questionId": 209,
+      "category": "Mind",
+      "difficultyTier": "Tier2",
+      "title": "Endgame",
+      "text": "How does this end?",
+      "answers": [
+        { "text": "With a question mark.", "answerClass": "Typical",
+          "explanation": "Very literal—and correct. The sentence ends with a '?'." },
+        { "text": "With an “s.”",          "answerClass": "Revelatory",
+          "explanation": "You saw the other layer. The word 'ends' terminates with the letter S." },
+        { "text": "With everyone still sane.", "answerClass": "Wrong",
+          "explanation": "We make no such promises. That is a meta-commentary, not an answer." }
+      ]
+    }
+
+    /* ---- IDs 210-320 ready for future additions ---- */
+  ]
+}

--- a/src/engine/constants.js
+++ b/src/engine/constants.js
@@ -1,0 +1,11 @@
+export const CLASS_SCORES = {
+  Typical:     { points: 2, thread: 0 },
+  Revelatory:  { points: 1, thread: 1 },
+  Wrong:       { points: 0, thread: -1 }
+};
+
+export const TRAIT_MAP = {
+  Typical:     { X: +1,  Y: 0,  Z: -1 },
+  Revelatory:  { X: 0,   Y: +2, Z: +1 },
+  Wrong:       { X: -1,  Y: -1, Z: 0  }
+};

--- a/src/engine/questionEngine.js
+++ b/src/engine/questionEngine.js
@@ -1,0 +1,69 @@
+import { CLASS_SCORES, TRAIT_MAP } from './constants.js';
+import raw from '../data/questions.json' assert { type: 'json' };
+
+const pools = {
+  Tier1: raw.questions.filter(q => q.difficultyTier === 'Tier1'),
+  Tier2: raw.questions.filter(q => q.difficultyTier === 'Tier2'),
+  Tier3: raw.questions.filter(q => q.difficultyTier === 'Tier3')
+};
+
+function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+export class QuestionEngine {
+  constructor() {
+    this.tier = 'Tier1';
+    this.answered = new Set();
+    this.drawnThisTier = 0;
+  }
+
+  nextQuestion() {
+    const tierOrder = this.tier === 'Tier3'
+      ? ['Tier3', 'Tier2', 'Tier1']
+      : this.tier === 'Tier2'
+      ? ['Tier2', 'Tier1']
+      : ['Tier1'];
+
+    for (const t of tierOrder) {
+      const pool = pools[t].filter(q => !this.answered.has(q.questionId));
+      if (pool.length) {
+        const q = shuffle(pool)[0];
+        this.randomizeAnswers(q);
+        return q;
+      }
+    }
+    return null; // everything answered
+  }
+
+  randomizeAnswers(q) { q.answers = shuffle([...q.answers]); }
+
+  resolve(qId, answerIndex, state) {
+    const q = raw.questions.find(q => q.questionId === qId);
+    const ans = q.answers[answerIndex];
+    const { points, thread } = CLASS_SCORES[ans.answerClass];
+
+    state.points  += points;
+    state.thread  += thread;
+
+    const traitDelta = ans.traits || TRAIT_MAP[ans.answerClass];
+    Object.keys(traitDelta).forEach(k => {
+      state.traits[k] = (state.traits[k] || 0) + traitDelta[k];
+    });
+
+    this.answered.add(qId);
+    this.drawnThisTier++;
+
+    if ((this.drawnThisTier >= 4 ||
+        !pools[this.tier].some(q => !this.answered.has(q.questionId)))
+        && this.tier !== 'Tier3') {
+      this.drawnThisTier = 0;
+      this.tier = this.tier === 'Tier1' ? 'Tier2' : 'Tier3';
+    }
+    return ans; // for UI feedback
+  }
+}


### PR DESCRIPTION
## Summary
- add expanded question set under `src/data/`
- define scoring constants for question responses
- implement `QuestionEngine` for tier-based question flow
- log improvement

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687b0fabdd108332b4cb584205c6820c