### PR TITLE
Fix pull-thread to use QuestionEngine

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
       window.zod = z;
     </script>
     <!-- Scripts are deferred to ensure elements exist before execution -->
+    <script type="module" src="src/engine/questionEngine.js"></script>
     <script src="state.js" defer></script>
     <script src="ui.js" defer></script>
     <script type="module" src="src/fate/fateEngine.js"></script>

--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -47,3 +47,4 @@
 - Integrated CDN import for fate engine validation so browser module resolves without bundler.
 - Removed duplicate DYN005 thread bonus to keep start of round balanced.
 - Added QuestionEngine module with tiered questions for modular trivia management.
+- Routed pull-thread to new QuestionEngine so tiered questions progress correctly.

--- a/src/engine/questionEngine.js
+++ b/src/engine/questionEngine.js
@@ -67,3 +67,7 @@ export class QuestionEngine {
     return ans; // for UI feedback
   }
 }
+
+if (typeof window !== 'undefined') {
+  window.QuestionEngine = QuestionEngine;
+}


### PR DESCRIPTION
## Summary
- load the QuestionEngine module before state.js
- expose QuestionEngine to the window for non-module access
- route `pull-thread` question draws through the new engine
- log the improvement

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ba267e52c8332a6dc25855afd2816