### PR TITLE
Fix fate and question flows

### DIFF
--- a/__tests__/button-flow.test.js
+++ b/__tests__/button-flow.test.js
@@ -1,0 +1,87 @@
+const fs = require('fs');
+const path = require('path');
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+const { JSDOM } = require('jsdom');
+
+describe('tempt fate and pull thread UI', () => {
+  let dom;
+  beforeEach(async () => {
+    jest.useFakeTimers();
+
+    global.fetch = jest.fn((url) => {
+      if (url.includes('questions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([
+          { questionId: 1, category: 'Mind', title: 'Q1', text: 'T1', answers: [
+            { text: 'A', answerClass: 'Typical' },
+            { text: 'B', answerClass: 'Wrong' },
+            { text: 'C', answerClass: 'Wrong' }
+          ] }
+        ]) });
+      }
+      if (url.includes('fate-cards')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([
+          { id: 'F1', title: 'FateCard', text: 'Do it', choices: [
+            { label: 'A', effect: {} }
+          ] }
+        ]) });
+      }
+      if (url.includes('divinations')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    });
+
+    const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
+    dom = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost' });
+    const wnd = dom.window;
+    wnd.fetch = global.fetch;
+    const inject = (code, type = 'text/javascript') => {
+      const s = wnd.document.createElement('script');
+      s.textContent = code;
+      s.type = type;
+      wnd.document.body.appendChild(s);
+    };
+    inject(fs.readFileSync(path.join(__dirname, '../state.js'), 'utf8'));
+    inject(fs.readFileSync(path.join(__dirname, '../ui.js'), 'utf8'));
+    wnd.Fate = {
+      draw: () => ({ id: 'F1', title: 'FateCard', text: 'Do it', choices: [{ label: 'A', effect: {} }] }),
+      getButtonLabels: () => ['A', '', ''],
+      choose: () => {},
+      resolveRound: () => ({})
+    };
+    inject(fs.readFileSync(path.join(__dirname, '../script.js'), 'utf8'));
+    wnd.document.dispatchEvent(new wnd.Event('DOMContentLoaded'));
+    jest.runAllTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetModules();
+    if (dom) { dom.window.close(); dom = null; }
+  });
+
+  test('tempt-fate shows card title', () => {
+    const h = dom.window.handleAction;
+    h('welcome-select');
+    h('participants-confirm');
+    jest.advanceTimersByTime(2000);
+    h('tempt-fate');
+    jest.runAllTimers();
+    const title = dom.window.document.getElementById('fate-card-title').textContent;
+    expect(title).toBe('FateCard');
+  });
+
+  test('pull thread shows question text', () => {
+    const h = dom.window.handleAction;
+    h('welcome-select');
+    h('participants-confirm');
+    jest.advanceTimersByTime(2000);
+    h('next-round');
+    h('start-question');
+    jest.runAllTimers();
+    const qText = dom.window.document.getElementById('question-text').textContent;
+    expect(qText).toBe('T1');
+  });
+});

--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -48,3 +48,4 @@
 - Removed duplicate DYN005 thread bonus to keep start of round balanced.
 - Added QuestionEngine module with tiered questions for modular trivia management.
 - Routed pull-thread to new QuestionEngine so tiered questions progress correctly.
+- Fixed Tempt Fate handler and UI labels to prevent undefined choices.

--- a/script.js
+++ b/script.js
@@ -126,18 +126,22 @@ document.addEventListener('DOMContentLoaded', () => {
         UI.updateScreen('welcome');
         attachWelcomeKeys();
         break;
-      case 'pull-divination':
+      case 'tempt-fate': {
         if (typeof Fate === 'undefined') break;
         const card = Fate.draw();
-        if (card) {
-          UI.showFate(card);
-          UI.setButtonLabels(Fate.getButtonLabels());
-          ['btn-1','btn-2','btn-3'].forEach((id,i)=>{
-            document.getElementById(id).onclick = () => Fate.choose(i);
-          });
-          UI.updateScreen('fate-card');
-        }
+        if (!card) break;
+        State.setCurrentFateCard(card);
+        UI.showFate(card);
+        UI.setButtonLabels(Fate.getButtonLabels());
+        ['btn-1','btn-2','btn-3'].forEach((id,i)=>{
+          document.getElementById(id).onclick = () => {
+            Fate.choose(i);
+            UI.updateScreen('game-lobby');
+          };
+        });
+        UI.updateScreen('fate-card');
         break;
+      }
       case 'next-round':
         State.startNewRound();
         UI.updateDisplayValues(State.getState());

--- a/state.js
+++ b/state.js
@@ -63,6 +63,11 @@ const State = (() => {
       questionDeck = await questionsRes.json();
       fateCardDeck = await fateCardsRes.json();
       divinationDeck = await divinationsRes.json();
+      console.table({
+        questions: questionDeck.length,
+        fates: fateCardDeck.length,
+        divs: divinationDeck.length
+      });
     } catch (err) {
       console.error('[LOAD DATA]', err);
       fateCardDeck = [];

--- a/style.css
+++ b/style.css
@@ -117,6 +117,11 @@ body {
   text-shadow: 1px 1px 1px rgba(0,0,0,0.4);
 }
 
+button.hidden {
+  visibility: hidden;
+  pointer-events: none;
+}
+
 .button-container {
   display: flex;
   justify-content: center;

--- a/ui.js
+++ b/ui.js
@@ -1,7 +1,7 @@
 // === Valid Actions Set === //
 const validActions = new Set([
   'start-game', 'go-rules', 'go-options', 'back-to-welcome',
-  'save-and-quit', 'pull-divination', 'next-round',
+  'save-and-quit', 'tempt-fate', 'next-round',
   'end-round', 'double-points', 'start-question',
   'answer-a', 'answer-b', 'answer-c',
   'challenge-result', 'accept-result', 'return-to-lobby',
@@ -35,7 +35,7 @@ const buttonConfigs = {
   ],
   "game-lobby": [
     { label: "Turn Back", action: "save-and-quit" },
-    { label: "Tempt Fate", action: "pull-divination" },
+    { label: "Tempt Fate", action: "tempt-fate" },
     { label: "Press On", action: "next-round" }
   ],
   "round-lobby": [
@@ -188,8 +188,9 @@ const UI = (() => {
     ['btn1', 'btn2', 'btn3'].forEach((id, i) => {
       const btn = buttons[id];
       const label = arr[i] || '';
-      btn.querySelector('.button-label').innerText = label;
+      btn.querySelector('.button-label').innerText = label || ' ';
       btn.disabled = label === '';
+      btn.classList.toggle('hidden', label === '');
     });
   };
 // Inside the UI IIFE


### PR DESCRIPTION
## Summary
- wire `tempt-fate` action to Fate engine and store chosen card
- hide controller buttons without labels
- log deck sizes when loading game data
- add CSS for hidden buttons
- provide regression tests for fate and question flows
- note improvement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ba7ba61d483329cb6073de657d5b1