### PR TITLE
Integrate trait tracking and scoring constants

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -50,3 +50,4 @@
 - Routed pull-thread to new QuestionEngine so tiered questions progress correctly.
 - Fixed Tempt Fate handler and UI labels to prevent undefined choices.
 - Hard-wired local decks to remove fetch dependency and speed up tests.
+- Integrated class score constants and trait tracking in State.

--- a/validator.js
+++ b/validator.js
@@ -24,6 +24,7 @@ const gameStateSchema = z.object({
   currentCategory: z.string(),
   divinations: z.array(z.any()),
   roundAnswerTally: z.object({ A: z.number(), B: z.number(), C: z.number() }),
+  traits: z.object({ X: z.number(), Y: z.number(), Z: z.number() }),
   activePowerUps: z.array(z.any())
 });
 


### PR DESCRIPTION
## Summary
- add CLASS_SCORES and TRAIT_MAP constants to state
- track trait totals in game state
- compute score and thread changes from the constants
- extend state validator
- log improvement

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bc00d77c48332887378f29ce14e22