### PR TITLE
Load question deck at init

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -51,3 +51,4 @@
 - Fixed Tempt Fate handler and UI labels to prevent undefined choices.
 - Hard-wired local decks to remove fetch dependency and speed up tests.
 - Integrated class score constants and trait tracking in State.
+- Forced QuestionEngine to accept loaded JSON deck for reliable draws.

--- a/src/engine/questionEngine.js
+++ b/src/engine/questionEngine.js
@@ -1,11 +1,12 @@
 import { CLASS_SCORES, TRAIT_MAP } from './constants.js';
-import raw from '../data/questions.json' assert { type: 'json' };
+// The QuestionEngine expects a preloaded deck of question objects.
+// This keeps the engine flexible and removes any direct data fetching logic.
 
-const pools = {
-  Tier1: raw.questions.filter(q => q.difficultyTier === 'Tier1'),
-  Tier2: raw.questions.filter(q => q.difficultyTier === 'Tier2'),
-  Tier3: raw.questions.filter(q => q.difficultyTier === 'Tier3')
-};
+let defaultDeck = [];
+
+export function setDefaultDeck(deck) {
+  defaultDeck = Array.isArray(deck) ? deck : [];
+}
 
 function shuffle(arr) {
   for (let i = arr.length - 1; i > 0; i--) {
@@ -16,10 +17,16 @@ function shuffle(arr) {
 }
 
 export class QuestionEngine {
-  constructor() {
+  constructor(questionDeck = defaultDeck) {
     this.tier = 'Tier1';
     this.answered = new Set();
     this.drawnThisTier = 0;
+    this.deck = Array.isArray(questionDeck) ? questionDeck : [];
+    this.pools = {
+      Tier1: this.deck.filter(q => q.difficultyTier === 'Tier1'),
+      Tier2: this.deck.filter(q => q.difficultyTier === 'Tier2'),
+      Tier3: this.deck.filter(q => q.difficultyTier === 'Tier3')
+    };
   }
 
   nextQuestion() {
@@ -30,7 +37,7 @@ export class QuestionEngine {
       : ['Tier1'];
 
     for (const t of tierOrder) {
-      const pool = pools[t].filter(q => !this.answered.has(q.questionId));
+      const pool = this.pools[t].filter(q => !this.answered.has(q.questionId));
       if (pool.length) {
         const q = shuffle(pool)[0];
         this.randomizeAnswers(q);
@@ -43,7 +50,7 @@ export class QuestionEngine {
   randomizeAnswers(q) { q.answers = shuffle([...q.answers]); }
 
   resolve(qId, answerIndex, state) {
-    const q = raw.questions.find(q => q.questionId === qId);
+    const q = this.deck.find(q => q.questionId === qId);
     const ans = q.answers[answerIndex];
     const { points, thread } = CLASS_SCORES[ans.answerClass];
 
@@ -59,7 +66,7 @@ export class QuestionEngine {
     this.drawnThisTier++;
 
     if ((this.drawnThisTier >= 4 ||
-        !pools[this.tier].some(q => !this.answered.has(q.questionId)))
+        !this.pools[this.tier].some(q => !this.answered.has(q.questionId)))
         && this.tier !== 'Tier3') {
       this.drawnThisTier = 0;
       this.tier = this.tier === 'Tier1' ? 'Tier2' : 'Tier3';

--- a/state.js
+++ b/state.js
@@ -18,7 +18,7 @@ const TRAIT_MAP = {
 const State = (() => {
   // --- Game Data ---
   let questionDeck = [];
-  const qEngine = typeof QuestionEngine !== 'undefined' ? new QuestionEngine() : null;
+  let qEngine = null;
 
   // Basic fallback Fate Deck in case the external file fails to load
   const defaultFateDeck = [
@@ -63,6 +63,7 @@ const State = (() => {
     answeredThisRound: []
   };
 
+  // Load decks from local files and prepare the question engine.
   const loadData = async () => {
     try {
       const [{ default: fateDeck }, { default: questions }] = await Promise.all([
@@ -72,23 +73,14 @@ const State = (() => {
       fateCardDeck = [...fateDeck];
       questionDeck = [...questions];
       divinationDeck = [];
-
-      if (typeof window !== 'undefined' && window.ENABLE_REMOTE_DECKS) {
-        try {
-          const [f, q] = await Promise.all([
-            fetch('fate-cards.json').then(r => r.json()),
-            fetch('questions/questions.json').then(r => r.json())
-          ]);
-          fateCardDeck = f;
-          questionDeck = q;
-        } catch (err) {
-          console.warn('[remote-deck] fetch failed, using local data', err);
-        }
+      if (typeof QuestionEngine !== 'undefined') {
+        qEngine = new QuestionEngine(questionDeck);
       }
     } catch (err) {
       console.error('[LOAD DATA]', err);
       fateCardDeck = [];
       questionDeck = [];
+      qEngine = null;
     }
   };
 
@@ -294,49 +286,14 @@ const State = (() => {
 
   // --- Question Logic ---
   const getNextQuestion = () => {
-    if (qEngine) {
-      const q = qEngine.nextQuestion();
-      if (!q) { console.warn('[QUESTION]: Deck exhausted'); return null; }
-      gameState.currentQuestion = q;
-      gameState.currentAnswers = q.answers.slice();
-    } else {
-      if (questionDeck.length === 0) {
-        console.warn('[QUESTION]: Deck is empty');
-        return null;
-      }
-
-      const { difficultyLevel, answeredQuestionIds } = gameState;
-
-      const minId = (difficultyLevel - 1) * 10 + 1;
-      const maxId = difficultyLevel * 10 - 1;
-
-      let available = questionDeck.filter(q =>
-        q.questionId >= minId &&
-        q.questionId <= maxId &&
-        !answeredQuestionIds.has(q.questionId)
-      );
-
-      if (available.length === 0) {
-        advanceDifficulty();
-        const newMin = (gameState.difficultyLevel - 1) * 10 + 1;
-        const newMax = gameState.difficultyLevel * 10 - 1;
-        available = questionDeck.filter(q =>
-          q.questionId >= newMin &&
-          q.questionId <= newMax &&
-          !answeredQuestionIds.has(q.questionId)
-        );
-      }
-
-      if (available.length === 0) {
-        console.warn('[QUESTION]: No available questions for any difficulty.');
-        return null;
-      }
-
-      const idx = Math.floor(Math.random() * available.length);
-      const q = available[idx];
-      gameState.currentQuestion = q;
-      gameState.currentAnswers = q.answers.slice();
+    if (!qEngine) {
+      console.warn('[QUESTION]: Engine unavailable');
+      return null;
     }
+    const q = qEngine.nextQuestion();
+    if (!q) { console.warn('[QUESTION]: Deck exhausted'); return null; }
+    gameState.currentQuestion = q;
+    gameState.currentAnswers = q.answers.slice();
 
     shuffleArray(gameState.currentAnswers);
 


### PR DESCRIPTION
## Summary
- pass preloaded deck to `QuestionEngine`
- instantiate the engine from local `questionDeck` when loading data
- simplify question selection logic to always use the engine
- log improvement

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bcfcb0f28833295d1ea7d03c8b3c4