### PR TITLE
Replace JSON imports with modules

### DIFF
--- a/src/data/fateDeck.js
+++ b/src/data/fateDeck.js
@@ -1,3 +1,95 @@
-/** Hard-wired Dynamics deck */
-import deck from '../../fate-cards.json' assert { type: 'json' };
-export default deck;
+export default [
+  {
+    "id": "DYN001",
+    "title": "The Candle and the Pyre",
+    "rarity": "Common",
+    "tags": ["Choice", "Wager", "Score"],
+    "text": "A moth whispers to you as it flutters by. 'Isn't the fire beautiful?' You have two choices:\n- Catch the moth and gain two points now.\n- Let it go, and for this round, every 'C' answer will earn you an extra point.",
+    "choices": [
+      {
+        "label": "Now",
+        "effect": {
+          "type": "IMMEDIATE_SCORE",
+          "value": 2,
+          "flavorText": "You snatch the moth from the air. Its dust glitters on your fingers as you feel a surge of insight."
+        }
+      },
+      {
+        "label": "Wait",
+        "effect": {
+          "type": "APPLY_WAGER",
+          "target": "answer-c",
+          "reward": { "type": "SCORE", "value": 1 },
+          "flavorText": "You let the moth spiral towards the flame. You feel a strange connection to its fate, tied to your future choices."
+        }
+      },
+      { "label": "Ignore" }
+    ]
+  },
+  {
+    "id": "DYN002",
+    "title": "Predictive Loop",
+    "rarity": "Uncommon",
+    "tags": ["Prediction", "Gamble", "Score"],
+    "text": "Nous knows what you will choose. Do you? Predict which answer ('A', 'B', or 'C') you will select most frequently this round. If you are correct, your round score will be doubled.",
+    "choices": [
+      { "label": "Predict 'A'", "effect": { "type": "ROUND_PREDICTION", "prediction": "A" } },
+      { "label": "Predict 'B'", "effect": { "type": "ROUND_PREDICTION", "prediction": "B" } },
+      { "label": "Predict 'C'", "effect": { "type": "ROUND_PREDICTION", "prediction": "C" } }
+    ],
+    "duration": "round",
+    "resolveAt": "endOfRound",
+    "reward": { "type": "DOUBLE_ROUND_SCORE" }
+  },
+  {
+    "id": "DYN003",
+    "title": "The Forked Path",
+    "rarity": "Uncommon",
+    "tags": ["Risk", "Modifier", "High-Stakes"],
+    "audacityMin": 2,
+    "text": "The path splits. Choose your burden for this round. Survive, and gain a reward of 3 points.",
+    "choices": [
+      { "label": "Veil", "effect": { "type": "ROUND_MODIFIER", "modifier": "VEIL", "flavorText": "A fog clouds your vision. The answers become indistinct shapes." } },
+      { "label": "Weight", "effect": { "type": "ROUND_MODIFIER", "modifier": "WEIGHT", "flavorText": "Every misstep feels heavier. The thread groans under the strain." } }
+    ],
+    "duration": "round",
+    "resolveAt": "endOfRound",
+    "reward": { "type": "SCORE", "value": 3 }
+  },
+  {
+    "id": "DYN004",
+    "title": "The Tallyman's Gambit",
+    "rarity": "Uncommon",
+    "tags": ["Gamble", "Consequence", "Pact"],
+    "text": "You accept the Tallyman's Gambit. Each time you answer 'C' this round, a tally is marked. The final count will determine your fate.",
+      "choices": [
+        { "label": "Accept", "effect": { "type": "TALLY_TABLE", "target": "C", "table": { "0": { "type": "DOUBLE_ROUND_SCORE" } } } }
+      ],
+    "duration": "round",
+    "resolveAt": "endOfRound"
+  },
+  {
+    "id": "DYN005",
+    "title": "Scholar's Boon",
+    "rarity": "Common",
+    "tags": ["Utility", "Safety"],
+    "text": "Scholar's Boon: Your knowledge protects you.\nGain +1 Thread at the start of this round.",
+    "choices": [
+      {
+        "label": "Accept Boon",
+        "effect": {
+          "type": "POWER_UP",
+          "power": "REMOVE_WRONG_ANSWER",
+          "flavorText": "You feel a quiet confidence. One of the wrong paths fades from view, leaving only certainty and a single doubt."
+        }
+      },
+      {
+        "label": "Turn it down",
+        "effect": {
+          "type": "SCORE",
+          "value": -1
+        }
+      }
+    ]
+  }
+];

--- a/src/data/questionDeck.js
+++ b/src/data/questionDeck.js
@@ -1,2 +1,418 @@
-import deck from '../../questions/questions.json' assert { type: 'json' };
-export default deck;
+export default [
+  {
+    "questionId": 101,
+    "category": "Mind",
+    "difficultyTier": "Tier1",
+    "title": "The Shape of Things",
+    "text": "Which of these has 3 sides?",
+    "answers": [
+      {
+        "text": "Triangle",
+        "answerClass": "Typical",
+        "explanation": "Of course you’d say that. And you're not wrong. A triangle has three sides."
+      },
+      {
+        "text": "Square",
+        "answerClass": "Revelatory",
+        "explanation": "No, a Tri- oh. That is also right. A square has three sides... and one more."
+      },
+      {
+        "text": "Circle",
+        "answerClass": "Wrong",
+        "explanation": "Not even close. A circle is a curve without any sides."
+      }
+    ]
+  },
+  {
+    "questionId": 102,
+    "category": "Mind",
+    "difficultyTier": "Tier1",
+    "title": "Capital Offense",
+    "text": "What is the capital of France?",
+    "answers": [
+      {
+        "text": "Paris",
+        "answerClass": "Typical",
+        "explanation": "We thought you’d say that. Paris is the capital city of France."
+      },
+      {
+        "text": "The letter F",
+        "answerClass": "Revelatory",
+        "explanation": "Well, hmm. Yes, 'F' is the capital letter in 'France'."
+      },
+      {
+        "text": "Versailles",
+        "answerClass": "Wrong",
+        "explanation": "Versailles was once the capital, but is not today."
+      }
+    ]
+  },
+  {
+    "questionId": 103,
+    "category": "Mind",
+    "difficultyTier": "Tier1",
+    "title": "No It Isn’t",
+    "text": "What is between 1 and 3?",
+    "answers": [
+      {
+        "text": "2",
+        "answerClass": "Typical",
+        "explanation": "That’s what the last one said. Numerically, 2 lies between 1 and 3."
+      },
+      {
+        "text": "and",
+        "answerClass": "Revelatory",
+        "explanation": "Great. Right. The word 'and' is between the numerals."
+      },
+      {
+        "text": "what",
+        "answerClass": "Wrong",
+        "explanation": "Incorrect. 'What' is not between the numbers."
+      }
+    ]
+  },
+  {
+    "questionId": 104,
+    "category": "Mind",
+    "difficultyTier": "Tier1",
+    "title": "Merry Unbirthday",
+    "text": "How many birthdays does the average person have?",
+    "answers": [
+      {
+        "text": "About Fifty",
+        "answerClass": "Typical",
+        "explanation": "That’s right, on average  a person will have 50 such anniversaries in a modern lifespan."
+      },
+      {
+        "text": "One",
+        "answerClass": "Revelatory",
+        "explanation": "Ah, a literalist. We like that. You are only born once; the rest are just parties."
+      },
+      {
+        "text": "Depends on how many friends they have",
+        "answerClass": "Wrong",
+        "explanation": "A charming thought, but incorrect. Parties don't change the number of times you were born."
+      }
+    ]
+  },
+  {
+    "questionId": 105,
+    "category": "Body",
+    "difficultyTier": "Tier1",
+    "title": "Eye Witness",
+    "text": "What can’t you do if your eyes are closed?",
+    "answers": [
+      {
+        "text": "See",
+        "answerClass": "Typical",
+        "explanation": "You cannot see with your eyes shut. But I guess it depends on what you were trying to see. Or trying not to."
+      },
+      {
+        "text": "Close them",
+        "answerClass": "Revelatory",
+        "explanation": "We figured you’d say that. You cannot perform an action on something already in that state."
+      },
+      {
+        "text": "Read",
+        "answerClass": "Wrong",
+        "explanation": "A flawed assumption. Braille can be read with your eyes closed."
+      }
+    ]
+  },
+  {
+    "questionId": 106,
+    "category": "Mind",
+    "difficultyTier": "Tier1",
+    "title": "Just the Two of Us",
+    "text": "What does 2 and 2 make?",
+    "answers": [
+      {
+        "text": "Four",
+        "answerClass": "Typical",
+        "explanation": "Math class paid off. Correct, 2 + 2 = 4."
+      },
+      {
+        "text": "Twenty-Two",
+        "answerClass": "Revelatory",
+        "explanation": "You saw the loophole. When concatenated, the numerals '2' and '2' form 22."
+      },
+      {
+        "text": "Eight",
+        "answerClass": "Wrong",
+        "explanation": "Oh, wow, you’ll have to show us how you got that."
+      }
+    ]
+  },
+  {
+    "questionId": 107,
+    "category": "Mind",
+    "difficultyTier": "Tier1",
+    "title": "I Know This One",
+    "text": "Which month has 28 days?",
+    "answers": [
+      {
+        "text": "February",
+        "answerClass": "Typical",
+        "explanation": "The one everyone remembers. February typically has exactly 28 days."
+      },
+      {
+        "text": "All of them",
+        "answerClass": "Revelatory",
+        "explanation": "You didn't fall for the trap. Every single month has *at least* 28 days."
+      },
+      {
+        "text": "None of them",
+        "answerClass": "Wrong",
+        "explanation": "Incorrect. Check your calendar again."
+      }
+    ]
+  },
+  {
+    "questionId": 108,
+    "category": "Body",
+    "difficultyTier": "Tier1",
+    "title": "Clovers and Blue Moons",
+    "text": "What’s at the end of a rainbow?",
+    "answers": [
+      {
+        "text": "A pot of gold",
+        "answerClass": "Typical",
+        "explanation": "Chasing myths, are we? Folklore says a leprechaun’s treasure lies at the end."
+      },
+      {
+        "text": "Violet",
+        "answerClass": "Revelatory",
+        "explanation": "A mind of science. In physics, the visible spectrum ends at violet."
+      },
+      {
+        "text": "Rainbows aren’t real.",
+        "answerClass": "Wrong",
+        "explanation": "Is anything? Are we?"
+      }
+    ]
+  },
+  {
+    "questionId": 109,
+    "category": "Soul",
+    "difficultyTier": "Tier1",
+    "title": "What’s in It?",
+    "text": "What did Schrödinger do with his box?",
+    "answers": [
+      {
+        "text": "Ended up inspiring the Many-Worlds interpretation.",
+        "answerClass": "Typical",
+        "explanation": "Causation or correlation? Either way, sure."
+      },
+      {
+        "text": "Tried to illustrate the problem with Quantum Mechanics.",
+        "answerClass": "Revelatory",
+        "explanation": "Schrödinger's experiment was a critique of quantum mechanics, not an endorsement."
+      },
+      {
+        "text": "Killed a cat.",
+        "answerClass": "Wrong",
+        "explanation": "Don't believe the rumors. No cat was harmed in the making of this thought experiment."
+      }
+    ]
+  },
+  {
+    "questionId": 201,
+    "category": "Mind",
+    "difficultyTier": "Tier2",
+    "title": "Payday",
+    "text": "If you’re told you’ll be paid biweekly, how often do you get paid?",
+    "answers": [
+      {
+        "text": "Every two weeks.",
+        "answerClass": "Typical",
+        "explanation": "Just like at the office. Most workplaces use 'biweekly' to mean every two weeks."
+      },
+      {
+        "text": "Twice each week.",
+        "answerClass": "Revelatory",
+        "explanation": "You consulted the dictionary, didn't you? It has two official meanings."
+      },
+      {
+        "text": "Whenever payroll processes the batch.",
+        "answerClass": "Wrong",
+        "explanation": "A cynical take, but not an answer."
+      }
+    ]
+  },
+  {
+    "questionId": 202,
+    "category": "Soul",
+    "difficultyTier": "Tier2",
+    "title": "Styx and Stones",
+    "text": "What is needed when you meet Charon at the River Styx?",
+    "answers": [
+      {
+        "text": "A coin",
+        "answerClass": "Typical",
+        "explanation": "You remembered the toll. Greek rites demand a coin for the ferryman."
+      },
+      {
+        "text": "Passage",
+        "answerClass": "Revelatory",
+        "explanation": "You see the true need. The coin only buys the journey you require."
+      },
+      {
+        "text": "A heart as light as a feather",
+        "answerClass": "Wrong",
+        "explanation": "Wrong mythology. That's an Egyptian trial, not a Greek one."
+      }
+    ]
+  },
+  {
+    "questionId": 203,
+    "category": "Body",
+    "difficultyTier": "Tier2",
+    "title": "It’s Other People",
+    "text": "In order to leave a room, you must…?",
+    "answers": [
+      {
+        "text": "Exit it.",
+        "answerClass": "Typical",
+        "explanation": "You can try."
+      },
+      {
+        "text": "Enter it.",
+        "answerClass": "Revelatory",
+        "explanation": "Ah, the prerequisite. You cannot leave a room you were never in to begin with."
+      },
+      {
+        "text": "Imagine it.",
+        "answerClass": "Wrong",
+        "explanation": "But what then? What if you can’t… stop imagining it?"
+      }
+    ]
+  },
+  {
+    "questionId": 204,
+    "category": "Body",
+    "difficultyTier": "Tier2",
+    "title": "The Great Divide",
+    "text": "What separates one meal from another?",
+    "answers": [
+      {
+        "text": "Time",
+        "answerClass": "Typical",
+        "explanation": "The clock rules all. Most people mark meals by time of day."
+      },
+      {
+        "text": "Space",
+        "answerClass": "Revelatory",
+        "explanation": "A very physical answer. Two meals cannot occupy the same space at the same time."
+      },
+      {
+        "text": "Gravity",
+        "answerClass": "Wrong",
+        "explanation": "Incorrect. Gravity acts on all meals; it does not separate them."
+      }
+    ]
+  },
+  {
+    "questionId": 205,
+    "category": "Body",
+    "difficultyTier": "Tier2",
+    "title": "On Your Marx",
+    "text": "How do you prevent the working class from revolting?",
+    "answers": [
+      {
+        "text": "Bread and circuses",
+        "answerClass": "Typical",
+        "explanation": "The classic Roman solution. Pacify the masses with cheap comforts."
+      },
+      {
+        "text": "They can’t revolt if they’re dead",
+        "answerClass": "Revelatory",
+        "explanation": "A chilling thought. But in terms of cold logic: an infallible solution."
+      },
+      {
+        "text": "Give them cake",
+        "answerClass": "Wrong",
+        "explanation": "That's just a rumor. And famously bad advice. Incorrect."
+      }
+    ]
+  },
+  {
+    "questionId": 206,
+    "category": "Body",
+    "difficultyTier": "Tier2",
+    "title": "A Nice Trip",
+    "text": "What is the shortest distance between two points?",
+    "answers": [
+      {
+        "text": "A straight line.",
+        "answerClass": "Typical",
+        "explanation": "Thinking on a flat plane, are we? Correct, in Euclidean space."
+      },
+      {
+        "text": "A geodesic",
+        "answerClass": "Revelatory",
+        "explanation": "You think in curves. On a sphere like Earth, a geodesic is the true shortest path."
+      },
+      {
+        "text": "A circle",
+        "answerClass": "Wrong",
+        "explanation": "A circle is never the shortest path between two points."
+      }
+    ]
+  },
+  {
+    "questionId": 207,
+    "category": "Soul",
+    "difficultyTier": "Tier2",
+    "title": "Imperial Memory",
+    "text": "Which of these was a Roman Emperor?",
+    "answers": [
+      {
+        "text": "Marcus Aurelius",
+        "answerClass": "Typical",
+        "explanation": "The philosopher-king. He's the one we all like to remember."
+      },
+      {
+        "text": "Caligula",
+        "answerClass": "Revelatory",
+        "explanation": "The inconvenient truth. He was an emperor, even if we'd rather forget."
+      },
+      {
+        "text": "Julius Caesar",
+        "answerClass": "Wrong",
+        "explanation": "A common myth. Caesar was a dictator, but he never held the title of emperor."
+      }
+    ]
+  },
+  {
+    "questionId": 208,
+    "category": "Mind",
+    "difficultyTier": "Tier2",
+    "title": "All Cretans",
+    "text": "TBD – please provide final wording & answers",
+    "answers": []
+  },
+  {
+    "questionId": 209,
+    "category": "Mind",
+    "difficultyTier": "Tier2",
+    "title": "Endgame",
+    "text": "How does this end?",
+    "answers": [
+      {
+        "text": "With a question mark.",
+        "answerClass": "Typical",
+        "explanation": "Very literal. And correct. The sentence ends with a '?'."
+      },
+      {
+        "text": "With an “s.”",
+        "answerClass": "Revelatory",
+        "explanation": "You saw the other layer. The word 'ends' terminates with the letter S."
+      },
+      {
+        "text": "With everyone still sane.",
+        "answerClass": "Wrong",
+        "explanation": "We make no such promises. That is a meta-commentary, not an answer."
+      }
+    ]
+  }
+];

--- a/src/fate/fateEngine.js
+++ b/src/fate/fateEngine.js
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import deckData from '../../fate-cards.json' assert { type: 'json' };
+import deckData from '../data/fateDeck.js';
 import { FateCard } from './schema.js';
 
 const DeckSchema = z.array(FateCard);

--- a/src/fate/loadDeck.js
+++ b/src/fate/loadDeck.js
@@ -1,5 +1,5 @@
 import { FateCard } from './schema.js';
-import cards from '../../fate-cards.json' assert { type: 'json' };
+import cards from '../data/fateDeck.js';
 
 const sanitize = (card) => ({
   id: card.id,


### PR DESCRIPTION
## Summary
- convert static JSON imports to JS modules
- update imports for new modules

## Testing
- `npm run lint:fix`
- `NODE_OPTIONS=--experimental-vm-modules npm test --silent`
- `npm run dev` *(fails: vite missing at first, installed; server starts)*

------
https://chatgpt.com/codex/tasks/task_e_687c1d7d6ecc8332b8e18f39a6564377