### PR TITLE
Fix question deck loading

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -62,3 +62,4 @@
 
 - Added Vite dev dependency so `npm run dev` launches correctly for local playtesting.
 - Alerted when question deck runs out so players know the thread is spent.
+- Loaded questions from JSON with JS fallback so new decks appear in game.

--- a/state.js
+++ b/state.js
@@ -104,11 +104,14 @@ const State = (() => {
   // Load decks from local files and prepare the question engine.
   const loadData = async () => {
     try {
-      const [{ default: fateDeck }, { default: questions }] = await Promise.all([
+      const [{ default: fateDeck }, questionsMod] = await Promise.all([
         import('./src/data/fateDeck.js'),
-        import('./src/data/questionDeck.js'),
+        import('./questions/questions.json', { with: { type: 'json' } })
+          .catch(() => import('./src/data/questions.json', { with: { type: 'json' } }))
+          .catch(() => import('./src/data/questionDeck.js')),
       ]);
-      const qDeck = Array.isArray(questions.questions) ? questions.questions : questions;
+      const qData = questionsMod.default ?? questionsMod;
+      const qDeck = Array.isArray(qData.questions) ? qData.questions : qData;
       fateCardDeck = [...fateDeck];
       questionDeck = [...qDeck];
       gameState.fateCardDeck = [...fateDeck];


### PR DESCRIPTION
## Summary
- load decks from `questions/questions.json` with fallback to existing JS files
- record update in improvements log

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c5e172f608332a7055f985fa4af58