### PR TITLE
Centralize trait constants and update tests

### DIFF
--- a/__tests__/button-flow.test.js
+++ b/__tests__/button-flow.test.js
@@ -22,6 +22,10 @@ describe('tempt fate and pull thread UI', () => {
       s.type = type;
       wnd.document.body.appendChild(s);
     };
+    const mod = p => fs.readFileSync(path.join(__dirname, p), 'utf8')
+      .replace(/export const (\w+) =/g, 'window.$1 =');
+    inject(mod('../src/engine/constants.js'));
+    inject(mod('../src/engine/traitLoadings.js'));
     inject(fs.readFileSync(path.join(__dirname, '../state.js'), 'utf8'));
     inject(fs.readFileSync(path.join(__dirname, '../ui.js'), 'utf8'));
     wnd.Fate = {

--- a/__tests__/smoke.test.js
+++ b/__tests__/smoke.test.js
@@ -22,6 +22,10 @@ describe('basic playthrough', () => {
       s.type = type;
       wnd.document.body.appendChild(s);
     };
+    const mod = p => fs.readFileSync(path.join(__dirname, p), 'utf8')
+      .replace(/export const (\w+) =/g, 'window.$1 =');
+    inject(mod('../src/engine/constants.js'));
+    inject(mod('../src/engine/traitLoadings.js'));
     inject(fs.readFileSync(path.join(__dirname, '../state.js'), 'utf8'));
     inject(fs.readFileSync(path.join(__dirname, '../ui.js'), 'utf8'));
     inject(fs.readFileSync(path.join(__dirname, '../src/fate/fateEngine.js'), 'utf8'), 'module');

--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -64,3 +64,4 @@
 - Alerted when question deck runs out so players know the thread is spent.
 - Loaded questions from JSON with JS fallback so new decks appear in game.
 - Filtered malformed questions and completed missing Tier 2 entry so draws advance past first 4 cards without crashing.
+- Centralized trait constants in engine modules for easier reuse and maintenance.

--- a/src/engine/constants.js
+++ b/src/engine/constants.js
@@ -15,3 +15,9 @@ export const CLASS_TRAIT_BASE = {
   Revelatory: { X: +2, Y: +3, Z: +2 },
   Wrong:      { X: -2, Y: -2, Z: -2 }
 };
+
+if (typeof window !== 'undefined') {
+  window.CLASS_SCORES = CLASS_SCORES;
+  window.TRAIT_MAP = TRAIT_MAP;
+  window.CLASS_TRAIT_BASE = CLASS_TRAIT_BASE;
+}

--- a/src/engine/traitLoadings.js
+++ b/src/engine/traitLoadings.js
@@ -39,3 +39,7 @@ export const TRAIT_LOADINGS = {
   208: { /* TBD */ },
   209: { axisWeight: { Z: 0 } }
 };
+
+if (typeof window !== 'undefined') {
+  window.TRAIT_LOADINGS = TRAIT_LOADINGS;
+}

--- a/state.js
+++ b/state.js
@@ -3,65 +3,10 @@
  * Manages the game's internal state.
  */
 
-const CLASS_SCORES = {
-  Typical:     { points: 2, thread: 0 },
-  Revelatory:  { points: 1, thread: 1 },
-  Wrong:       { points: 0, thread: -1 }
-};
-
-const TRAIT_MAP = {
-  Typical:     { X: +1,  Y: 0,  Z: -1 },
-  Revelatory:  { X: 0,   Y: +2, Z: +1 },
-  Wrong:       { X: -1,  Y: -1, Z: 0  }
-};
-
-const CLASS_TRAIT_BASE = {
-  Typical:    { X: -1, Y: -1, Z: -1 },
-  Revelatory: { X: +2, Y: +3, Z: +2 },
-  Wrong:      { X: -2, Y: -2, Z: -2 }
-};
-
-const TRAIT_LOADINGS = {
-  /* ---------- Tier-1 ---------- */
-  101: { axisWeight: { Z: 0 } },
-  103: { axisWeight: { Z: 0 } },
-  104: { axisWeight: { Z: 0.5 } },
-  105: { axisWeight: { Z: 0 } },
-  106: { axisWeight: { Z: 0 } },
-  107: { axisWeight: { Z: 0.5 } },
-
-  /* Custom per-answer override example */
-  108: {
-    axisWeight: { Z: 1.5 },
-    overrides: {
-      Typical:     { Z: -3 },
-      Revelatory:  { X: -1, Y: 0,  Z: +2 },
-      Wrong:       { X: -2, Y: +1, Z: +1 }
-    }
-  },
-
-  109: { axisWeight: { Z: 1.5 } },
-
-  /* ---------- Tier-2 ---------- */
-  201: { axisWeight: { Z: 0 } },
-  202: { axisWeight: { Z: 1.5 } },
-  203: { axisWeight: { Z: 0 } },
-  204: { axisWeight: { Z: 0 } },
-
-  205: {
-    axisWeight: { X: 0.5, Y: 0.7, Z: 1.2 },
-    overrides: {
-      Typical:     { X: +1, Y: -2, Z: -2 },
-      Revelatory:  { X: -2, Y: +4, Z: +2 },
-      Wrong:       { X: -2, Y: +1, Z: -3 }
-    }
-  },
-
-  206: { axisWeight: { Z: 1 } },
-  207: { axisWeight: { Z: 1.5 } },
-  208: { /* TBD */ },
-  209: { axisWeight: { Z: 0 } }
-};
+let CLASS_SCORES;
+let TRAIT_MAP;
+let CLASS_TRAIT_BASE;
+let TRAIT_LOADINGS;
 
 const State = (() => {
   // --- Game Data ---
@@ -102,6 +47,13 @@ const State = (() => {
   };
 
   // Load decks from local files and prepare the question engine.
+  if (typeof window !== 'undefined') {
+    CLASS_SCORES = window.CLASS_SCORES;
+    TRAIT_MAP = window.TRAIT_MAP;
+    CLASS_TRAIT_BASE = window.CLASS_TRAIT_BASE;
+    TRAIT_LOADINGS = window.TRAIT_LOADINGS;
+  }
+
   const loadData = async () => {
     try {
       const [{ default: fateDeck }, questionsMod] = await Promise.all([


### PR DESCRIPTION
## Summary
- refactor `state.js` to pull trait constants from `window`
- expose constants globally in `src/engine/constants.js` and `traitLoadings.js`
- load those modules in tests by transforming to plain scripts
- log improvement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c667581e48332800a1a225c1bafd7