### PR TITLE
Add saved state validation on load

### DIFF
--- a/__tests__/loadGame.test.js
+++ b/__tests__/loadGame.test.js
@@ -1,0 +1,9 @@
+import '../state.js';
+
+test('corrupted save data is rejected', async () => {
+  localStorage.setItem('nous-save', '{"bad":true}');
+  const before = window.State.getState();
+  const result = await window.State.loadGame();
+  expect(result).toBe(false);
+  expect(window.State.getState()).toEqual(before);
+});

--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -64,3 +64,4 @@
 - Alerted when question deck runs out so players know the thread is spent.
 - Loaded questions from JSON with JS fallback so new decks appear in game.
 - Filtered malformed questions and completed missing Tier 2 entry so draws advance past first 4 cards without crashing.
+- Validated saved state before loading to prevent corrupt resumes.

--- a/script.js
+++ b/script.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // --- Game Initialization ---
   async function init() {
     await State.loadData();
-    const resumed = State.loadGame();
+    const resumed = await State.loadGame();
     if (resumed) {
       UI.updateDisplayValues(State.getState());
       UI.updateScreen(State.getState().currentScreen || 'game-lobby');

--- a/state.js
+++ b/state.js
@@ -504,11 +504,18 @@ const State = (() => {
     }
   };
 
-  const loadGame = () => {
+  const loadGame = async () => {
     try {
       const data = localStorage.getItem('nous-save');
       if (!data) return false;
       const saved = JSON.parse(data);
+      const { validateGameState } = await import('./validator.js');
+      try {
+        validateGameState(saved);
+      } catch (err) {
+        console.error('[LOAD VALIDATION]', err);
+        return false;
+      }
       gameState = { ...gameState, ...saved };
       return true;
     } catch (err) {


### PR DESCRIPTION
## Summary
- ensure saved data is validated before merging into game state
- await loadGame in init so validation can run
- reject corrupted save data with new Jest coverage
- document the new validation step

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c667fd190833297875c3097e26b4a