### PR TITLE
Fix script path for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@700&family=EB+Garamond&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
     <!-- Load the main game bundle via Vite -->
-    <script type="module" src="/src/script.js"></script>
+    <script type="module" src="./src/script.js"></script>
 </head>
 <body>
 

--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -67,3 +67,4 @@
 - Validated saved state before loading to prevent corrupt resumes.
 - Centralized trait constants in engine modules for easier reuse and maintenance.
 - Configured Vite base path and documented GitHub Pages deployment.
+- Fixed relative script path so GitHub Pages loads the main module.


### PR DESCRIPTION
## Summary
- fix absolute script path in `index.html`
- log improvement entry

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ca17c22d0833296342839758c04d4